### PR TITLE
feat: add flake.nix and base NixOS configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "NixOS configuration for desktop-01";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, home-manager, ... }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      nixosConfigurations.desktop-01 = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./hosts/desktop-01
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+          }
+        ];
+      };
+
+      formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
+      formatter.aarch64-linux = nixpkgs.legacyPackages.aarch64-linux.nixfmt-rfc-style;
+      formatter.x86_64-darwin = nixpkgs.legacyPackages.x86_64-darwin.nixfmt-rfc-style;
+      formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-rfc-style;
+    };
+}

--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -1,0 +1,39 @@
+{ pkgs, ... }:
+{
+  imports = [
+    ./hardware-configuration.nix
+  ];
+
+  # Bootloader
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  # Networking
+  networking.hostName = "desktop-01";
+  networking.networkmanager.enable = true;
+
+  # Bluetooth
+  hardware.bluetooth.enable = true;
+
+  # Timezone and locale
+  time.timeZone = "Asia/Tokyo";
+  i18n.defaultLocale = "ja_JP.UTF-8";
+
+  # User account
+  users.users.aoshima = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "networkmanager"
+    ];
+  };
+
+  # Basic packages
+  environment.systemPackages = with pkgs; [
+    vim
+    git
+    wget
+  ];
+
+  system.stateVersion = "25.05";
+}

--- a/hosts/desktop-01/hardware-configuration.nix
+++ b/hosts/desktop-01/hardware-configuration.nix
@@ -1,0 +1,23 @@
+# Placeholder: replace with output of `nixos-generate-config` on the actual machine.
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/boot";
+    fsType = "vfat";
+  };
+}


### PR DESCRIPTION
## Summary

- `flake.nix`: nixpkgs (unstable) + home-manager inputs, `nixosConfigurations.desktop-01` definition, nixfmt formatter config
- `hosts/desktop-01/default.nix`: systemd-boot + EFI, NetworkManager + WiFi + Bluetooth, locale (ja_JP.UTF-8), timezone (Asia/Tokyo), user account (aoshima)
- `hosts/desktop-01/hardware-configuration.nix`: placeholder to be replaced after running `nixos-generate-config` on the actual machine

Closes #2

## Test plan

- [ ] `nix flake check` passes (CI Linux runner)
- [ ] `nixfmt --check` passes on all `.nix` files
- [ ] gitleaks detects no secrets
- [ ] After replacing `hardware-configuration.nix` on actual machine, `sudo nixos-rebuild switch --flake .#desktop-01` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)