### PR TITLE
Add NVIDIA proprietary driver configuration for RTX A400

### DIFF
--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/nvidia.nix
   ];
 
   # Bootloader

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+{
+  # NVIDIA proprietary driver
+  hardware.nvidia = {
+    modesetting.enable = true;
+    open = false;
+    package = config.boot.kernelPackages.nvidiaPackages.stable;
+  };
+
+  # OpenGL
+  hardware.graphics.enable = true;
+
+  # Load nvidia driver for Xorg and Wayland
+  services.xserver.videoDrivers = [ "nvidia" ];
+
+  # Wayland-specific environment variables
+  environment.sessionVariables = {
+    NIXOS_OZONE_WL = "1";
+    WLR_NO_HARDWARE_CURSORS = "1";
+  };
+}


### PR DESCRIPTION
## Summary

- Add `modules/nvidia.nix` with NVIDIA proprietary driver configuration (modesetting, closed-source driver, OpenGL)
- Set Wayland-specific environment variables (`NIXOS_OZONE_WL`, `WLR_NO_HARDWARE_CURSORS`)
- Import the module from `hosts/desktop-01/default.nix`

Closes #3

## Test plan

- [ ] `nix flake check` passes
- [ ] NixOS build completes without errors (`nix build .#nixosConfigurations.desktop-01.config.system.build.toplevel`)
- [ ] After `nixos-rebuild switch`, NVIDIA driver is loaded (`nvidia-smi` works)
- [ ] Hyprland renders correctly with hardware cursor visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)