### PR TITLE
Integrate Home Manager with basic user environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
+            home-manager.users.aoshima = import ./home;
           }
         ];
       };

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,0 +1,14 @@
+{ ... }:
+{
+  home.username = "aoshima";
+  home.homeDirectory = "/home/aoshima";
+  home.stateVersion = "25.05";
+
+  programs.zsh.enable = true;
+
+  programs.git = {
+    enable = true;
+    userName = "Shuji Aoshima";
+    userEmail = "47586723+aoshimash@users.noreply.github.com";
+  };
+}


### PR DESCRIPTION
## Summary

- Enable Home Manager as a NixOS module with `home-manager.users.aoshima`
- Add `home/default.nix` with Zsh shell and Git basic settings (user.name, user.email)
- Minimal initial setup; more configuration to be added incrementally

Closes #5

## Test plan

- [ ] `nix flake check` passes
- [ ] `nixfmt --check` passes (CI format check)
- [ ] NixOS build succeeds on Linux CI runner
- [ ] `sudo nixos-rebuild switch --flake .#desktop-01` applies successfully on NixOS machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)