### PR TITLE
Allow unfree packages for NVIDIA driver CI build

### DIFF
--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -1,5 +1,8 @@
 { pkgs, ... }:
 {
+  # Allow unfree packages (e.g. NVIDIA driver)
+  nixpkgs.config.allowUnfree = true;
+
   imports = [
     ./hardware-configuration.nix
     ../../modules/nvidia.nix


### PR DESCRIPTION
## Summary

- Add `nixpkgs.config.allowUnfree = true` to `hosts/desktop-01/default.nix`
- Fixes the CI "NixOS build check" failure caused by the unfree `nvidia-x11` package

Closes #13

## Test plan

- [ ] CI "NixOS build check" job passes
- [ ] `nix build .#nixosConfigurations.desktop-01.config.system.build.toplevel` succeeds without `--impure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)