### PR TITLE
Add Nix binary cache to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix fmt -- --check .
 
   secrets:
@@ -31,4 +32,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build .#nixosConfigurations.desktop-01.config.system.build.toplevel


### PR DESCRIPTION
## Summary
- Add `DeterminateSystems/magic-nix-cache-action` to the format and build CI jobs
- Enables GitHub Actions cache as a Nix binary cache for faster subsequent builds

Closes #15

## Changes
- `.github/workflows/ci.yml`: Added `magic-nix-cache-action@main` step after `nix-installer-action` in both `format` and `build` jobs

## Test Plan
- [ ] CI runs successfully with the new cache action
- [ ] Second CI run on the same branch shows reduced build time from cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)