### PR TITLE
Eliminate redundant CI workflow runs and enable auto-cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   format:


### PR DESCRIPTION
## Summary

- Restrict `push` trigger to `main` branch only, so PR branches trigger CI only via the `pull_request` event (eliminating duplicate runs)
- Add `concurrency` settings to automatically cancel outdated in-progress CI runs when new commits are pushed to the same branch/PR

Closes #22

## Test plan

- [ ] Push a commit to a branch with an open PR → verify only one CI run triggers (not two)
- [ ] Push a commit to `main` → verify CI triggers once via push event
- [ ] Push a new commit to a PR while CI is running → verify the previous run is cancelled
- [ ] Verify all three jobs (format, secrets, build) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
