### PR TITLE
Replace NixOS full build with lightweight eval checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
           aqua_version: v2.45.0
       - run: gitleaks detect
 
-  build:
-    name: NixOS build check
+  nixos-config:
+    name: NixOS config check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build .#nixosConfigurations.desktop-01.config.system.build.toplevel
+      - run: nix flake check
+      - run: nix eval .#nixosConfigurations.desktop-01.config.system.build.toplevel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,10 @@ nix fmt
 # Lint & check
 nix flake check
 
-# Build without applying (CI does this on Linux)
+# Evaluate NixOS config without building (CI does this on Linux)
+nix eval .#nixosConfigurations.desktop-01.config.system.build.toplevel
+
+# Build without applying (run on NixOS machine)
 nix build .#nixosConfigurations.desktop-01.config.system.build.toplevel
 
 # Apply on NixOS machine
@@ -82,10 +85,10 @@ sops secrets/secrets.yaml
 
 - Format check (`nixfmt --check`)
 - Secret detection (`gitleaks`)
-- NixOS build check (Linux runner)
+- NixOS config check (`nix flake check` + `nix eval`)
 
 ## Testing Strategy
 
 - **Mac (editing)**: format, lint, gitleaks, `nix flake check` (partial)
-- **CI (Linux)**: full build check
-- **NixOS machine**: `nixos-rebuild switch` (final apply)
+- **CI (Linux)**: config eval check (`nix flake check` + `nix eval`)
+- **NixOS machine**: full build (`nix build`) + `nixos-rebuild switch` (final apply)


### PR DESCRIPTION
## Summary

- Replace `nix build` (9-12 min) with `nix flake check` + `nix eval` (seconds) in CI
- Remove `magic-nix-cache-action` from the build job (no longer needed)
- Update CLAUDE.md to reflect new testing strategy

Closes #23

## Changes
- `.github/workflows/ci.yml`: Replace full NixOS build with flake check + eval, remove magic-nix-cache-action
- `CLAUDE.md`: Update Development Commands, CI section, and Testing Strategy

## Context

Investigation (see [comment](https://github.com/aoshimash/nixos-config/issues/23#issuecomment-4016112812)) revealed the slow CI is caused by 163 derivations being rebuilt from source every run (~9.5 min), not by cache size limits. This is a cache invalidation problem — nixpkgs revision changes invalidate all derivation hashes.

`nix flake check` + `nix eval` catches Nix expression errors, module option mismatches, and missing imports, covering the majority of issues from configuration changes. Full `nix build` verification is done locally on the NixOS machine.

## Test Plan
- [ ] CI `NixOS config check` job completes in under 5 minutes
- [ ] `nix flake check` detects flake structure issues
- [ ] `nix eval` detects NixOS config evaluation errors
- [ ] No secrets or sensitive data exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
