### PR TITLE
Add PipeWire audio configuration and volume keybindings

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -19,6 +19,13 @@
       "$mod" = "SUPER";
       "$terminal" = "ghostty";
 
+      bindl = [
+        ", XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 5%+"
+        ", XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
+        ", XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
+        ", XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
+      ];
+
       bind = [
         "$mod, Return, exec, $terminal"
         "$mod, Q, killactive"

--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -9,6 +9,7 @@
     ../../modules/hyprland.nix
     ../../modules/sops.nix
     ../../modules/fonts.nix
+    ../../modules/audio.nix
   ];
 
   # Bootloader

--- a/modules/audio.nix
+++ b/modules/audio.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+    wireplumber.enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
- Add `modules/audio.nix` with PipeWire (ALSA/PulseAudio compat + WirePlumber)
- Import audio module in `hosts/desktop-01/default.nix`
- Add media key volume bindings (`bindl`) in `home/hyprland.nix` for lock screen support

## Test plan
- [ ] `nix flake check` passes on CI
- [ ] On NixOS machine: `wpctl status` shows PipeWire running and audio devices listed
- [ ] Volume up/down/mute/mic-mute media keys work
- [ ] Media keys work on lock screen

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
