### PR TITLE
Add wofi application launcher for Hyprland

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ./hyprland.nix
     ./fcitx5.nix
+    ./wofi.nix
   ];
   home.username = "aoshima";
   home.homeDirectory = "/home/aoshima";

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -20,6 +20,7 @@
       "$terminal" = "kitty";
 
       bind = [
+        "$mod, D, exec, wofi --show drun"
         "$mod, Return, exec, $terminal"
         "$mod, Q, killactive"
         "$mod, M, exit"

--- a/home/wofi.nix
+++ b/home/wofi.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  programs.wofi.enable = true;
+}


### PR DESCRIPTION
## Summary
- Install wofi via Home Manager (`programs.wofi.enable`)
- Add `$mod + D` keybinding in Hyprland to launch `wofi --show drun`
- Create dedicated `home/wofi.nix` module following existing conventions

Closes #30

## Changes
- `home/wofi.nix` — New file: enable wofi via Home Manager
- `home/default.nix` — Import `./wofi.nix`
- `home/hyprland.nix` — Add wofi keybinding to bind list

## Test Plan
- [ ] `nix fmt` passes (verified locally with `nixfmt --check`)
- [ ] `nix flake check` passes (CI)
- [ ] `nixos-rebuild switch` succeeds on NixOS machine
- [ ] `$mod + D` opens wofi application launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
