### PR TITLE
Add Firefox and Google Chrome as web browsers

### DIFF
--- a/home/browsers.nix
+++ b/home/browsers.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  programs.firefox.enable = true;
+
+  home.packages = [
+    pkgs.google-chrome
+  ];
+}

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,6 +1,7 @@
 { ... }:
 {
   imports = [
+    ./browsers.nix
     ./hyprland.nix
     ./fcitx5.nix
     ./wofi.nix


### PR DESCRIPTION
## Summary

- Add Firefox via Home Manager `programs.firefox.enable` module
- Add Google Chrome via `home.packages` (unfree already allowed)
- Both browsers work on Wayland/Hyprland via existing `NIXOS_OZONE_WL=1`

Closes #29

## Test plan

- [ ] `nix flake check` passes
- [ ] `nixos-rebuild switch --flake .#desktop-01` applies successfully
- [ ] Firefox launches and runs on Wayland
- [ ] Google Chrome launches and runs on Wayland

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
