### PR TITLE
Add VS Code and Emacs editor configuration

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -4,6 +4,7 @@
     ./hyprland.nix
     ./fcitx5.nix
     ./wofi.nix
+    ./editors.nix
   ];
   home.username = "aoshima";
   home.homeDirectory = "/home/aoshima";

--- a/home/editors.nix
+++ b/home/editors.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  programs.vscode = {
+    enable = true;
+    package = pkgs.vscode;
+  };
+
+  programs.emacs.enable = true;
+}


### PR DESCRIPTION
## Summary

- Add `home/editors.nix` with VS Code (Microsoft build) and Emacs via Home Manager
- Import editors module from `home/default.nix`

Closes #31 (Cursor split to #37)

## Changes

- `home/editors.nix` (new): Configure `programs.vscode` (Microsoft build) and `programs.emacs`
- `home/default.nix`: Add `./editors.nix` to imports

## Test Plan

- [ ] `nix flake check` passes in CI
- [ ] `nixos-rebuild switch` succeeds on NixOS machine
- [ ] VS Code launches and runs on Wayland/Hyprland
- [ ] Emacs launches and runs on Wayland/Hyprland

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
