### PR TITLE
Add NixOS installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,168 @@
+# NixOS Installation Guide
+
+This guide covers the complete NixOS installation process from USB boot media creation to `nixos-install`, specific to this repository's `desktop-01` configuration.
+
+For post-install configuration (applying the flake, setting up monitors, etc.), see [setup.md](setup.md).
+
+## Prerequisites
+
+- A USB drive (2 GB or larger)
+- A Mac for creating the boot media
+- The target machine with **wired (Ethernet) connection**
+- Access to the age secret key (`~/.config/sops/age/keys.txt` on your Mac)
+
+## Step 1: Create USB Boot Media (from macOS)
+
+Download the latest NixOS minimal ISO from https://nixos.org/download/:
+
+```bash
+# Example (adjust URL for the latest version)
+curl -L -o nixos-minimal.iso https://channels.nixos.org/nixos-unstable/latest-nixos-minimal-x86_64-linux.iso
+```
+
+Identify the USB drive:
+
+```bash
+diskutil list
+```
+
+Find your USB drive (e.g., `/dev/disk4`). **Double-check the disk number** — writing to the wrong disk will destroy data.
+
+Unmount the USB drive and write the ISO:
+
+```bash
+diskutil unmountDisk /dev/diskN
+sudo dd if=nixos-minimal.iso of=/dev/rdiskN bs=4m status=progress
+```
+
+> **Note:** Use `/dev/rdiskN` (with the `r` prefix) for significantly faster writes.
+
+## Step 2: Boot from USB
+
+1. Insert the USB drive into the target machine.
+2. Enter the BIOS/UEFI boot menu (typically by pressing F12, F2, or Del during startup).
+3. Select the USB drive as the boot device (UEFI mode).
+4. NixOS will boot into a minimal environment with a root shell.
+
+## Step 3: Connect to the Network
+
+Verify wired Ethernet connectivity:
+
+```bash
+ping -c 3 nixos.org
+```
+
+If using Wi-Fi temporarily (the final system uses sops-nix managed credentials):
+
+```bash
+sudo systemctl start wpa_supplicant
+wpa_cli
+> add_network
+> set_network 0 ssid "YOUR_SSID"
+> set_network 0 psk "YOUR_PSK"
+> enable_network 0
+> quit
+```
+
+## Step 4: Partition and Format the Disk
+
+This configuration uses UEFI with systemd-boot. Create a GPT partition table with an EFI System Partition and a root partition.
+
+1. Identify the target disk:
+
+   ```bash
+   lsblk
+   ```
+
+2. Partition the disk (example using `/dev/nvme0n1`):
+
+   ```bash
+   parted /dev/nvme0n1 -- mklabel gpt
+   parted /dev/nvme0n1 -- mkpart root ext4 512MB 100%
+   parted /dev/nvme0n1 -- mkpart ESP fat32 1MB 512MB
+   parted /dev/nvme0n1 -- set 2 esp on
+   ```
+
+3. Format the partitions:
+
+   ```bash
+   mkfs.ext4 -L nixos /dev/nvme0n1p1
+   mkfs.fat -F 32 -n boot /dev/nvme0n1p2
+   ```
+
+4. Mount the partitions:
+
+   ```bash
+   mount /dev/disk/by-label/nixos /mnt
+   mkdir -p /mnt/boot
+   mount /dev/disk/by-label/boot /mnt/boot
+   ```
+
+## Step 5: Generate hardware-configuration.nix
+
+1. Generate the hardware configuration for the target machine:
+
+   ```bash
+   nixos-generate-config --root /mnt
+   ```
+
+   This creates `/mnt/etc/nixos/hardware-configuration.nix` with the correct hardware settings for your machine.
+
+2. Clone this repository:
+
+   ```bash
+   nix-shell -p git
+   git clone https://github.com/aoshimash/nixos-config.git /mnt/etc/nixos-config
+   ```
+
+3. Replace the placeholder `hardware-configuration.nix` with the generated one:
+
+   ```bash
+   cp /mnt/etc/nixos/hardware-configuration.nix /mnt/etc/nixos-config/hosts/desktop-01/hardware-configuration.nix
+   ```
+
+   > **Important:** After installation, commit this file to the repository so future rebuilds use the correct hardware configuration.
+
+## Step 6: Transfer the Age Decryption Key
+
+The sops-nix secrets (user password, Wi-Fi credentials) require the age decryption key to be present during installation.
+
+On your Mac, enable **Remote Login** (System Settings > General > Sharing > Remote Login).
+
+On the NixOS installer, copy the key from your Mac:
+
+```bash
+mkdir -p /mnt/var/lib/sops-nix
+scp <mac-user>@<Mac-IP>:~/.config/sops/age/keys.txt /mnt/var/lib/sops-nix/key.txt
+chmod 600 /mnt/var/lib/sops-nix/key.txt
+```
+
+> **Note:** The key must be at `/mnt/var/lib/sops-nix/key.txt` (under `/mnt`) during installation. After boot, it will be at `/var/lib/sops-nix/key.txt` as configured in `modules/sops.nix`.
+
+## Step 7: Install NixOS
+
+Run the installation from the cloned repository:
+
+```bash
+nixos-install --flake /mnt/etc/nixos-config#desktop-01
+```
+
+You will be prompted to set the root password. The user password for `aoshima` is managed by sops-nix and will be set automatically.
+
+> **Note:** The first install may take a while as it fetches and builds all dependencies.
+
+## Step 8: Reboot
+
+```bash
+reboot
+```
+
+Remove the USB drive when prompted or during the reboot.
+
+## Next Steps
+
+After booting into the installed system, follow the [Setup Guide](setup.md) for post-install configuration:
+
+- Applying configuration updates with `nixos-rebuild switch`
+- Identifying and configuring monitor output names for Hyprland
+- Troubleshooting common issues


### PR DESCRIPTION
## Summary

- Add `docs/installation.md` covering the full NixOS installation process from bare metal to a working system
- Documents USB boot media creation from macOS, disk partitioning (UEFI/GPT), `hardware-configuration.nix` generation, age key transfer via scp for sops-nix, and `nixos-install --flake`
- Links to existing `docs/setup.md` for post-install configuration

Closes #40

## Changes

- `docs/installation.md` — new file (168 lines)

## Test Plan

- [ ] Verify all commands are correct by following the guide on a fresh NixOS installation
- [ ] Confirm `docs/setup.md` link resolves correctly
- [ ] Review that the guide is consistent in style with `docs/setup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
