### PR TITLE
Replace Hyprland monitor placeholders with actual output names

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -4,11 +4,10 @@
     enable = true;
     settings = {
       # Monitor layout (left to right): JAPANNEXT 2K → DELL 2K → LG 4K
-      # TODO: Replace PLACEHOLDER-* with actual output names from `hyprctl monitors`
       monitor = [
-        "PLACEHOLDER-1, 2560x1440@144, 0x0, 1" # JAPANNEXT (left)
-        "PLACEHOLDER-2, 2560x1440@144, 2560x0, 1" # DELL G3223D (center)
-        "PLACEHOLDER-3, 3840x2160@60, 5120x0, 1.5" # LG HDR 4K (right)
+        "DP-6, 2560x1440@144, 0x0, 1" # JAPANNEXT (left)
+        "DP-9, 2560x1440@144, 2560x0, 1" # DELL G3223D (center)
+        "DP-8, 3840x2160@60, 5120x0, 1.5" # LG HDR 4K (right)
       ];
 
       input = {


### PR DESCRIPTION
## Summary

- Replace `PLACEHOLDER-1/2/3` with actual monitor output names (`DP-6`, `DP-9`, `DP-8`) identified via `hyprctl monitors` on desktop-01
- Remove the TODO comment as placeholders are now resolved

## Changes

- `home/hyprland.nix` — update monitor output names

## Test Plan

- [ ] `sudo nixos-rebuild switch --flake .#desktop-01` succeeds
- [ ] All three monitors display correctly with the expected layout (JAPANNEXT left, DELL center, LG right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
