### PR TITLE
Add desktop-01 machine reference and fix installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,9 +40,10 @@ sudo dd if=nixos-minimal.iso of=/dev/rdiskN bs=4m status=progress
 ## Step 2: Boot from USB
 
 1. Insert the USB drive into the target machine.
-2. Enter the BIOS/UEFI boot menu (typically by pressing F12, F2, or Del during startup).
-3. Select the USB drive as the boot device (UEFI mode).
-4. NixOS will boot into a minimal environment with a root shell.
+2. Enter the BIOS/UEFI settings and **disable Secure Boot** (typically under Security or Boot tab). NixOS minimal ISO does not support Secure Boot.
+3. Enter the BIOS/UEFI boot menu (typically by pressing F12, F2, or Del during startup).
+4. Select the USB drive as the boot device (UEFI mode).
+5. NixOS will boot into a minimal environment with a root shell.
 
 ## Step 3: Connect to the Network
 
@@ -77,25 +78,25 @@ This configuration uses UEFI with systemd-boot. Create a GPT partition table wit
 2. Partition the disk (example using `/dev/nvme0n1`):
 
    ```bash
-   parted /dev/nvme0n1 -- mklabel gpt
-   parted /dev/nvme0n1 -- mkpart root ext4 512MB 100%
-   parted /dev/nvme0n1 -- mkpart ESP fat32 1MB 512MB
-   parted /dev/nvme0n1 -- set 2 esp on
+   sudo parted /dev/nvme0n1 -- mklabel gpt
+   sudo parted /dev/nvme0n1 -- mkpart root ext4 512MB 100%
+   sudo parted /dev/nvme0n1 -- mkpart ESP fat32 1MB 512MB
+   sudo parted /dev/nvme0n1 -- set 2 esp on
    ```
 
 3. Format the partitions:
 
    ```bash
-   mkfs.ext4 -L nixos /dev/nvme0n1p1
-   mkfs.fat -F 32 -n boot /dev/nvme0n1p2
+   sudo mkfs.ext4 -L nixos /dev/nvme0n1p1
+   sudo mkfs.fat -F 32 -n boot /dev/nvme0n1p2
    ```
 
 4. Mount the partitions:
 
    ```bash
-   mount /dev/disk/by-label/nixos /mnt
-   mkdir -p /mnt/boot
-   mount /dev/disk/by-label/boot /mnt/boot
+   sudo mount /dev/disk/by-label/nixos /mnt
+   sudo mkdir -p /mnt/boot
+   sudo mount /dev/disk/by-label/boot /mnt/boot
    ```
 
 ## Step 5: Generate hardware-configuration.nix
@@ -103,7 +104,7 @@ This configuration uses UEFI with systemd-boot. Create a GPT partition table wit
 1. Generate the hardware configuration for the target machine:
 
    ```bash
-   nixos-generate-config --root /mnt
+   sudo nixos-generate-config --root /mnt
    ```
 
    This creates `/mnt/etc/nixos/hardware-configuration.nix` with the correct hardware settings for your machine.
@@ -111,14 +112,13 @@ This configuration uses UEFI with systemd-boot. Create a GPT partition table wit
 2. Clone this repository:
 
    ```bash
-   nix-shell -p git
-   git clone https://github.com/aoshimash/nixos-config.git /mnt/etc/nixos-config
+   sudo nix-shell -p git --run "git clone https://github.com/aoshimash/nixos-config.git /mnt/etc/nixos-config"
    ```
 
 3. Replace the placeholder `hardware-configuration.nix` with the generated one:
 
    ```bash
-   cp /mnt/etc/nixos/hardware-configuration.nix /mnt/etc/nixos-config/hosts/desktop-01/hardware-configuration.nix
+   sudo cp /mnt/etc/nixos/hardware-configuration.nix /mnt/etc/nixos-config/hosts/desktop-01/hardware-configuration.nix
    ```
 
    > **Important:** After installation, commit this file to the repository so future rebuilds use the correct hardware configuration.
@@ -132,9 +132,9 @@ On your Mac, enable **Remote Login** (System Settings > General > Sharing > Remo
 On the NixOS installer, copy the key from your Mac:
 
 ```bash
-mkdir -p /mnt/var/lib/sops-nix
-scp <mac-user>@<Mac-IP>:~/.config/sops/age/keys.txt /mnt/var/lib/sops-nix/key.txt
-chmod 600 /mnt/var/lib/sops-nix/key.txt
+sudo mkdir -p /mnt/var/lib/sops-nix
+sudo scp <mac-user>@<Mac-IP>:~/.config/sops/age/keys.txt /mnt/var/lib/sops-nix/key.txt
+sudo chmod 600 /mnt/var/lib/sops-nix/key.txt
 ```
 
 > **Note:** The key must be at `/mnt/var/lib/sops-nix/key.txt` (under `/mnt`) during installation. After boot, it will be at `/var/lib/sops-nix/key.txt` as configured in `modules/sops.nix`.
@@ -144,7 +144,7 @@ chmod 600 /mnt/var/lib/sops-nix/key.txt
 Run the installation from the cloned repository:
 
 ```bash
-nixos-install --flake /mnt/etc/nixos-config#desktop-01
+sudo nixos-install --flake /mnt/etc/nixos-config#desktop-01
 ```
 
 You will be prompted to set the root password. The user password for `aoshima` is managed by sops-nix and will be set automatically.
@@ -161,8 +161,21 @@ Remove the USB drive when prompted or during the reboot.
 
 ## Next Steps
 
-After booting into the installed system, follow the [Setup Guide](setup.md) for post-install configuration:
+After booting into the installed system:
 
-- Applying configuration updates with `nixos-rebuild switch`
-- Identifying and configuring monitor output names for Hyprland
-- Troubleshooting common issues
+1. Clone the repository to your home directory for day-to-day use:
+
+   ```bash
+   cd ~
+   git clone https://github.com/aoshimash/nixos-config.git
+   ```
+
+   The `/etc/nixos-config` clone from installation is no longer needed and can be removed:
+
+   ```bash
+   sudo rm -rf /etc/nixos-config
+   ```
+
+2. Follow the [Setup Guide](setup.md) for post-install configuration:
+   - Identifying and configuring monitor output names for Hyprland
+   - Troubleshooting common issues

--- a/docs/machines/desktop-01.md
+++ b/docs/machines/desktop-01.md
@@ -1,0 +1,44 @@
+# desktop-01: ThinkStation P3 Ultra SFF Gen 2
+
+Machine-specific reference for reproducing the NixOS installation on this hardware.
+
+## Hardware
+
+| Component | Detail |
+|-----------|--------|
+| Model | Lenovo ThinkStation P3 Ultra SFF Gen 2 |
+| Disk | NVMe SSD (`/dev/nvme0n1`, ~954 GB) |
+
+## BIOS/UEFI Notes
+
+- **Secure Boot** must be disabled (NixOS minimal ISO does not support it)
+
+## Partition Layout
+
+Created during installation (see [installation.md](../installation.md) Step 4):
+
+| Partition | Label | Type | Size | Mount |
+|-----------|-------|------|------|-------|
+| `nvme0n1p1` | `nixos` | ext4 | ~953 GB | `/` |
+| `nvme0n1p2` | `boot` | FAT32 | 512 MB | `/boot` |
+
+## Monitor Configuration
+
+Identified via `hyprctl monitors` (see [setup.md](../setup.md) Post-Boot Steps):
+
+| Output | Resolution | Position | Scale | Monitor |
+|--------|-----------|----------|-------|---------|
+| `DP-6` | 2560x1440@144 | 0x0 | 1 | JAPANNEXT (left) |
+| `DP-9` | 2560x1440@144 | 2560x0 | 1 | DELL G3223D (center) |
+| `DP-8` | 3840x2160@60 | 5120x0 | 1.5 | LG HDR 4K (right) |
+
+> **Note:** Monitor output names (DP-6, DP-9, DP-8) may change if cables are moved to different ports. Run `hyprctl monitors` to re-identify them.
+
+## Installation Notes
+
+Lessons learned from the initial installation (2026-03):
+
+- The NixOS live environment requires `sudo` for all disk/mount/install operations
+- Cloning the repo to `/mnt/etc/nixos-config` requires `sudo nix-shell -p git --run "git clone ..."`
+- After installation, clone the repo to `~/nixos-config` for daily use and remove `/etc/nixos-config`
+- Age key transfer via `scp` from Mac works well (Mac needs Remote Login enabled)


### PR DESCRIPTION
## Summary

- Add `docs/machines/desktop-01.md` with machine-specific hardware details, partition layout, monitor output names, and installation notes for the ThinkStation P3 Ultra SFF Gen 2
- Fix `docs/installation.md` based on lessons learned from the actual installation:
  - Add Secure Boot disable step
  - Add `sudo` to all commands that require root privileges
  - Fix `git clone` command to use `sudo nix-shell -p git --run "..."`
  - Add post-install instructions for cloning repo to home directory

## Changes

- `docs/machines/desktop-01.md` — new file
- `docs/installation.md` — fixes and improvements

## Test Plan

- [ ] Review that installation guide steps are reproducible as written
- [ ] Verify machine-specific info matches actual hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
