### PR TITLE
Add GitHub CLI (gh) to Home Manager configuration

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -31,6 +31,8 @@
 
   programs.zsh.enable = true;
 
+  programs.gh.enable = true;
+
   programs.git = {
     enable = true;
     userName = "Shuji Aoshima";


### PR DESCRIPTION
## Summary
- Enable `programs.gh` in Home Manager so `gh` CLI is available on the NixOS desktop
- Authentication is handled manually via `gh auth login` after deployment (no credentials in repo)

Closes #44

## Changes
- `home/default.nix`: Add `programs.gh.enable = true;`

## Test Plan
- [ ] `nix flake check` passes (CI)
- [ ] `gh --version` succeeds on the NixOS desktop after `nixos-rebuild switch`
- [ ] `gh auth login` can be run interactively to authenticate
- [ ] No authentication tokens or credentials are stored in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
