### PR TITLE
Enable gh git credential helper in Home Manager

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -31,7 +31,10 @@
 
   programs.zsh.enable = true;
 
-  programs.gh.enable = true;
+  programs.gh = {
+    enable = true;
+    gitCredentialHelper.enable = true;
+  };
 
   programs.git = {
     enable = true;


### PR DESCRIPTION
## Summary
- Enable `gitCredentialHelper` for `programs.gh` to fix `gh auth login` failing with "Read-only file system" error

Relates to #44

## Changes
- `home/default.nix`: Add `gitCredentialHelper.enable = true` to `programs.gh` config

## Context
After merging #45, `gh auth login` fails because it tries to write the git credential helper to `~/.config/git/config`, which Home Manager manages as a read-only symlink. Enabling `gitCredentialHelper` sets this declaratively.

## Test Plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] `gh auth login` completes without "Read-only file system" error
- [ ] `gh auth status` shows authenticated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
