### PR TITLE
Add Bluetooth GUI and Waybar status bar

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -5,6 +5,7 @@
     ./hyprland.nix
     ./fcitx5.nix
     ./wofi.nix
+    ./waybar.nix
     ./editors.nix
   ];
   home.username = "aoshima";

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -15,6 +15,11 @@
         kb_variant = "dvorak";
       };
 
+      exec-once = [
+        "waybar"
+        "blueman-applet"
+      ];
+
       "$mod" = "SUPER";
       "$terminal" = "ghostty";
 

--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -1,0 +1,64 @@
+{ ... }:
+{
+  programs.waybar = {
+    enable = true;
+    settings = {
+      mainBar = {
+        layer = "top";
+        position = "top";
+        height = 30;
+
+        modules-left = [ "hyprland/workspaces" ];
+        modules-center = [ "clock" ];
+        modules-right = [
+          "network"
+          "pulseaudio"
+          "bluetooth"
+          "tray"
+        ];
+
+        "hyprland/workspaces" = {
+          format = "{id}";
+        };
+
+        clock = {
+          format = "{:%Y-%m-%d %H:%M}";
+          tooltip-format = "{:%A, %B %d, %Y}";
+        };
+
+        network = {
+          format-wifi = "  {essid}";
+          format-ethernet = "󰈀  {ipaddr}";
+          format-disconnected = "󰖪  Disconnected";
+          tooltip-format = "{ifname}: {ipaddr}/{cidr}";
+        };
+
+        pulseaudio = {
+          format = "{icon}  {volume}%";
+          format-muted = "󰝟  Muted";
+          format-icons = {
+            default = [
+              "󰕿"
+              "󰖀"
+              "󰕾"
+            ];
+          };
+          on-click = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+        };
+
+        bluetooth = {
+          format = "󰂯 {status}";
+          format-connected = "󰂱 {device_alias}";
+          format-disabled = "󰂲";
+          on-click = "blueman-manager";
+          tooltip-format = "{controller_alias}\n{num_connections} connected";
+        };
+
+        tray = {
+          icon-size = 18;
+          spacing = 10;
+        };
+      };
+    };
+  };
+}

--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -10,6 +10,7 @@
     ../../modules/sops.nix
     ../../modules/fonts.nix
     ../../modules/audio.nix
+    ../../modules/bluetooth.nix
   ];
 
   # Bootloader
@@ -38,9 +39,6 @@
       ipv6.method = "auto";
     };
   };
-
-  # Bluetooth
-  hardware.bluetooth.enable = true;
 
   # Timezone and locale
   time.timeZone = "Asia/Tokyo";

--- a/modules/bluetooth.nix
+++ b/modules/bluetooth.nix
@@ -1,0 +1,9 @@
+{ ... }:
+{
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+  };
+
+  services.blueman.enable = true;
+}


### PR DESCRIPTION
## Summary
- Extract Bluetooth config into `modules/bluetooth.nix` with `powerOnBoot` and blueman service
- Add Waybar status bar via Home Manager with workspaces, clock, network, volume, bluetooth, and system tray
- Auto-start waybar and blueman-applet with Hyprland via `exec-once`

Closes #47

## Changes
- `modules/bluetooth.nix` — New module: `hardware.bluetooth` (enable + powerOnBoot) + `services.blueman`
- `hosts/desktop-01/default.nix` — Import bluetooth module, remove inline `hardware.bluetooth.enable`
- `home/waybar.nix` — New module: declarative Waybar config with all required modules
- `home/default.nix` — Import waybar module
- `home/hyprland.nix` — Add `exec-once` for waybar and blueman-applet

## Test Plan
- [ ] `nix flake check` passes (CI)
- [ ] `nix build` succeeds on NixOS machine
- [ ] `nixos-rebuild switch` applies successfully
- [ ] Waybar appears at top of screen with all modules visible
- [ ] blueman-applet appears in system tray
- [ ] Bluetooth devices can be paired via blueman-manager
- [ ] Bluetooth is powered on at boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
