### PR TITLE
feat: add mako notification daemon for Wayland

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -7,6 +7,7 @@
     ./wofi.nix
     ./waybar.nix
     ./editors.nix
+    ./mako.nix
   ];
   home.username = "aoshima";
   home.homeDirectory = "/home/aoshima";

--- a/home/mako.nix
+++ b/home/mako.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  services.mako = {
+    enable = true;
+    defaultTimeout = 5000;
+    anchor = "top-right";
+  };
+}


### PR DESCRIPTION
## Summary
- Add mako as a lightweight Wayland-native notification daemon via Home Manager
- Configure top-right anchor and 5-second auto-dismiss timeout
- Fix desktop notifications (e.g. blueman-applet) appearing stuck at screen center

Closes #51

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#desktop-01` succeeds
- [ ] `systemctl --user status mako` shows service running
- [ ] `notify-send "test"` displays notification at top-right
- [ ] Notification auto-dismisses after ~5 seconds
- [ ] blueman-applet notifications appear at top-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
