### PR TITLE
Migrate dotfiles to Home Manager modules

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 let
   aqua = pkgs.callPackage ../pkgs/aqua.nix { };
   freelens = pkgs.callPackage ../pkgs/freelens.nix { };
@@ -12,6 +12,8 @@ in
     ./waybar.nix
     ./editors.nix
     ./mako.nix
+    ./shell.nix
+    ./tmux.nix
   ];
   home.username = "aoshima";
   home.homeDirectory = "/home/aoshima";
@@ -30,7 +32,6 @@ in
     which
 
     # Development tools
-    tmux
     llvmPackages.clang
     claude-code
     go
@@ -53,12 +54,9 @@ in
     codex
     gemini-cli
 
-    # Shell productivity
-    fzf
+    # Shell productivity (fzf, zoxide, direnv are in shell.nix via programs.*)
     bat
     eza
-    zoxide
-    direnv
     lazygit
     delta
 
@@ -73,12 +71,28 @@ in
   ];
 
   home.file.".claude/CLAUDE.md".source = ./dotfiles/claude/CLAUDE.md;
+  home.file.".claude/settings.json".text = builtins.toJSON {
+    enabledPlugins = {
+      "gopls-lsp@claude-plugins-official" = true;
+    };
+    alwaysThinkingEnabled = true;
+    env = {
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+    };
+    teammateMode = "in-process";
+    statusLine = {
+      type = "command";
+      command = "sh ${config.home.homeDirectory}/.claude/statusline-command.sh";
+    };
+  };
+  home.file.".claude/statusline-command.sh" = {
+    source = ./dotfiles/claude/statusline-command.sh;
+    executable = true;
+  };
 
   home.sessionVariables = {
     PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
   };
-
-  programs.zsh.enable = true;
 
   programs.gh = {
     enable = true;

--- a/home/dotfiles/claude/statusline-command.sh
+++ b/home/dotfiles/claude/statusline-command.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+input=$(cat)
+model=$(echo "$input" | jq -r '.model.display_name')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir')
+context_pct=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | xargs printf '%.0f')
+dir=$(basename "$cwd")
+# Detect branch handling git worktrees correctly
+# git-dir is worktree-specific (e.g. .git/worktrees/<name> for linked worktrees)
+_git_dir=$(git -C "$cwd" --no-optional-locks rev-parse --git-dir 2>/dev/null)
+if [ -n "$_git_dir" ]; then
+  case "$_git_dir" in /*) ;; *) _git_dir="$cwd/$_git_dir" ;; esac
+  _head=$(cat "$_git_dir/HEAD" 2>/dev/null)
+  case "$_head" in
+    "ref: refs/heads/"*) branch="${_head#ref: refs/heads/}" ;;
+    *) branch=$(git -C "$cwd" --no-optional-locks rev-parse --short HEAD 2>/dev/null) ;;
+  esac
+fi
+
+# colors
+green=$(printf '\033[32m')
+yellow=$(printf '\033[33m')
+red=$(printf '\033[31m')
+cyan=$(printf '\033[36m')
+dim=$(printf '\033[2m')
+reset=$(printf '\033[0m')
+
+# context color: green < 50%, yellow < 80%, red >= 80%
+if [ "$context_pct" -ge 80 ] 2>/dev/null; then
+  ctx_color="$red"
+elif [ "$context_pct" -ge 50 ] 2>/dev/null; then
+  ctx_color="$yellow"
+else
+  ctx_color="$green"
+fi
+
+if [ -n "$branch" ]; then
+  staged=$(git -C "$cwd" --no-optional-locks diff --cached --numstat 2>/dev/null | wc -l | tr -d ' ')
+  modified=$(git -C "$cwd" --no-optional-locks diff --numstat 2>/dev/null | wc -l | tr -d ' ')
+  untracked=$(git -C "$cwd" --no-optional-locks ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+  git_status=""
+  [ "$staged" -gt 0 ] && git_status="${green}+${staged}${reset}"
+  [ "$modified" -gt 0 ] && git_status="${git_status} ${yellow}~${modified}${reset}"
+  [ "$untracked" -gt 0 ] && git_status="${git_status} ${red}?${untracked}${reset}"
+  git_info="${cyan}${branch}${reset}"
+  [ -n "$git_status" ] && git_info="$git_info $git_status"
+  printf "${dim}%s${reset}  %s  ${ctx_color}ctx:%s%%${reset}  ${dim}%s${reset}" "$dir" "$git_info" "$context_pct" "$model"
+else
+  printf "${dim}%s${reset}  ${ctx_color}ctx:%s%%${reset}  ${dim}%s${reset}" "$dir" "$context_pct" "$model"
+fi

--- a/home/dotfiles/tmux/tmux.conf.local
+++ b/home/dotfiles/tmux/tmux.conf.local
@@ -1,0 +1,256 @@
+# : << EOF
+# https://github.com/gpakosz/.tmux
+# (‑●‑●)> dual licensed under the WTFPL v2 license and the MIT license,
+#         without any warranty.
+#         Copyright 2012— Gregory Pakosz (@gpakosz).
+
+
+# -- navigation ----------------------------------------------------------------
+
+# if you're running tmux within iTerm2
+#   - and tmux is 1.9 or 1.9a
+#   - and iTerm2 is configured to let option key act as +Esc
+#   - and iTerm2 is configured to send [1;9A -> [1;9D for option + arrow keys
+# then uncomment the following line to make Meta + arrow keys mapping work
+#set -ga terminal-overrides "*:kUP3=\e[1;9A,*:kDN3=\e[1;9B,*:kRIT3=\e[1;9C,*:kLFT3=\e[1;9D"
+
+
+# -- windows & pane creation ---------------------------------------------------
+
+# new window retains current path, possible values are:
+#   - true
+#   - false (default)
+tmux_conf_new_window_retain_current_path=false
+
+# new pane retains current path, possible values are:
+#   - true (default)
+#   - false
+tmux_conf_new_pane_retain_current_path=true
+
+# new pane tries to reconnect ssh sessions (experimental), possible values are:
+#   - true
+#   - false (default)
+tmux_conf_new_pane_reconnect_ssh=false
+
+# prompt for session name when creating a new session, possible values are:
+#   - true
+#   - false (default)
+tmux_conf_new_session_prompt=false
+
+
+# -- display -------------------------------------------------------------------
+
+# RGB 24-bit colour support (tmux >= 2.2), possible values are:
+#  - true
+#  - false (default)
+tmux_conf_24b_colour=false
+
+# default theme
+tmux_conf_theme_colour_1="#080808"    # dark gray
+tmux_conf_theme_colour_2="#303030"    # gray
+tmux_conf_theme_colour_3="#8a8a8a"    # light gray
+tmux_conf_theme_colour_4="#00afff"    # light blue
+tmux_conf_theme_colour_5="#ffff00"    # yellow
+tmux_conf_theme_colour_6="#080808"    # dark gray
+tmux_conf_theme_colour_7="#e4e4e4"    # white
+tmux_conf_theme_colour_8="#080808"    # dark gray
+tmux_conf_theme_colour_9="#ffff00"    # yellow
+tmux_conf_theme_colour_10="#ff00af"   # pink
+tmux_conf_theme_colour_11="#5fff00"   # green
+tmux_conf_theme_colour_12="#8a8a8a"   # light gray
+tmux_conf_theme_colour_13="#e4e4e4"   # white
+tmux_conf_theme_colour_14="#080808"   # dark gray
+tmux_conf_theme_colour_15="#080808"   # dark gray
+tmux_conf_theme_colour_16="#d70000"   # red
+tmux_conf_theme_colour_17="#e4e4e4"   # white
+
+# window style
+tmux_conf_theme_window_fg="default"
+tmux_conf_theme_window_bg="default"
+
+# highlight focused pane (tmux >= 2.1), possible values are:
+#   - true
+#   - false (default)
+tmux_conf_theme_highlight_focused_pane=false
+
+# focused pane colours:
+tmux_conf_theme_focused_pane_bg="$tmux_conf_theme_colour_2"
+
+# pane border style, possible values are:
+#   - thin (default)
+#   - fat
+tmux_conf_theme_pane_border_style=thin
+
+# pane borders colours:
+tmux_conf_theme_pane_border="$tmux_conf_theme_colour_2"
+tmux_conf_theme_pane_active_border="$tmux_conf_theme_colour_4"
+
+# pane indicator colours (when you hit <prefix> + q)
+tmux_conf_theme_pane_indicator="$tmux_conf_theme_colour_4"
+tmux_conf_theme_pane_active_indicator="$tmux_conf_theme_colour_4"
+
+# status line style
+tmux_conf_theme_message_fg="$tmux_conf_theme_colour_1"
+tmux_conf_theme_message_bg="$tmux_conf_theme_colour_5"
+tmux_conf_theme_message_attr="bold"
+
+# status line command style (<prefix> : Escape)
+tmux_conf_theme_message_command_fg="$tmux_conf_theme_colour_5"
+tmux_conf_theme_message_command_bg="$tmux_conf_theme_colour_1"
+tmux_conf_theme_message_command_attr="bold"
+
+# window modes style
+tmux_conf_theme_mode_fg="$tmux_conf_theme_colour_1"
+tmux_conf_theme_mode_bg="$tmux_conf_theme_colour_5"
+tmux_conf_theme_mode_attr="bold"
+
+# status line style
+tmux_conf_theme_status_fg="$tmux_conf_theme_colour_3"
+tmux_conf_theme_status_bg="$tmux_conf_theme_colour_1"
+tmux_conf_theme_status_attr="none"
+
+# terminal title
+tmux_conf_theme_terminal_title="#h ❐ #S ● #I #W"
+
+# window status style
+tmux_conf_theme_window_status_fg="$tmux_conf_theme_colour_3"
+tmux_conf_theme_window_status_bg="$tmux_conf_theme_colour_1"
+tmux_conf_theme_window_status_attr="none"
+tmux_conf_theme_window_status_format="#I #W"
+
+# window current status style
+tmux_conf_theme_window_status_current_fg="$tmux_conf_theme_colour_1"
+tmux_conf_theme_window_status_current_bg="$tmux_conf_theme_colour_4"
+tmux_conf_theme_window_status_current_attr="bold"
+tmux_conf_theme_window_status_current_format="#I #W"
+
+# window activity status style
+tmux_conf_theme_window_status_activity_fg="default"
+tmux_conf_theme_window_status_activity_bg="default"
+tmux_conf_theme_window_status_activity_attr="underscore"
+
+# window bell status style
+tmux_conf_theme_window_status_bell_fg="$tmux_conf_theme_colour_5"
+tmux_conf_theme_window_status_bell_bg="default"
+tmux_conf_theme_window_status_bell_attr="blink,bold"
+
+# window last status style
+tmux_conf_theme_window_status_last_fg="$tmux_conf_theme_colour_4"
+tmux_conf_theme_window_status_last_bg="$tmux_conf_theme_colour_2"
+tmux_conf_theme_window_status_last_attr="none"
+
+# status left/right sections separators
+tmux_conf_theme_left_separator_main=""
+tmux_conf_theme_left_separator_sub="|"
+tmux_conf_theme_right_separator_main=""
+tmux_conf_theme_right_separator_sub="|"
+
+# status left/right content
+tmux_conf_theme_status_left=" ❐ #S |"
+tmux_conf_theme_status_right=""
+
+# status left style
+tmux_conf_theme_status_left_fg="$tmux_conf_theme_colour_6,$tmux_conf_theme_colour_7,$tmux_conf_theme_colour_8"
+tmux_conf_theme_status_left_bg="$tmux_conf_theme_colour_9,$tmux_conf_theme_colour_10,$tmux_conf_theme_colour_11"
+tmux_conf_theme_status_left_attr="bold,none,none"
+
+# status right style
+tmux_conf_theme_status_right_fg="$tmux_conf_theme_colour_12,$tmux_conf_theme_colour_13,$tmux_conf_theme_colour_14"
+tmux_conf_theme_status_right_bg="$tmux_conf_theme_colour_15,$tmux_conf_theme_colour_16,$tmux_conf_theme_colour_17"
+tmux_conf_theme_status_right_attr="none,none,bold"
+
+# pairing indicator
+tmux_conf_theme_pairing="⚇"                 # U+2687
+tmux_conf_theme_pairing_fg="none"
+tmux_conf_theme_pairing_bg="none"
+tmux_conf_theme_pairing_attr="none"
+
+# prefix indicator
+tmux_conf_theme_prefix="⌨"                  # U+2328
+tmux_conf_theme_prefix_fg="none"
+tmux_conf_theme_prefix_bg="none"
+tmux_conf_theme_prefix_attr="none"
+
+# mouse indicator
+tmux_conf_theme_mouse="↗"                   # U+2197
+tmux_conf_theme_mouse_fg="none"
+tmux_conf_theme_mouse_bg="none"
+tmux_conf_theme_mouse_attr="none"
+
+# root indicator
+tmux_conf_theme_root="!"
+tmux_conf_theme_root_fg="none"
+tmux_conf_theme_root_bg="none"
+tmux_conf_theme_root_attr="bold,blink"
+
+# synchronized indicator
+tmux_conf_theme_synchronized="⚏"            # U+268F
+tmux_conf_theme_synchronized_fg="none"
+tmux_conf_theme_synchronized_bg="none"
+tmux_conf_theme_synchronized_attr="none"
+
+# battery bar symbols
+tmux_conf_battery_bar_symbol_full="◼"
+tmux_conf_battery_bar_symbol_empty="◻"
+
+# battery bar length (in number of symbols), possible values are:
+#   - auto
+#   - a number, e.g. 5
+tmux_conf_battery_bar_length="auto"
+
+# battery bar palette, possible values are:
+#   - gradient (default)
+#   - heat
+#   - "colour_full_fg,colour_empty_fg,colour_bg"
+tmux_conf_battery_bar_palette="gradient"
+
+# battery hbar palette, possible values are:
+#   - gradient (default)
+#   - heat
+#   - "colour_low,colour_half,colour_full"
+tmux_conf_battery_hbar_palette="gradient"
+
+# battery vbar palette, possible values are:
+#   - gradient (default)
+#   - heat
+#   - "colour_low,colour_half,colour_full"
+tmux_conf_battery_vbar_palette="gradient"
+
+# symbols used to indicate whether battery is charging or discharging
+tmux_conf_battery_status_charging="↑"       # U+2191
+tmux_conf_battery_status_discharging="↓"    # U+2193
+
+# clock style (when you hit <prefix> + t)
+tmux_conf_theme_clock_colour="$tmux_conf_theme_colour_4"
+tmux_conf_theme_clock_style="24"
+
+
+# -- clipboard -----------------------------------------------------------------
+
+# in copy mode, copying selection also copies to the OS clipboard
+#   - true
+#   - false (default)
+# on Linux, this requires xsel or xclip
+tmux_conf_copy_to_os_clipboard=true
+
+
+# -- user customizations -------------------------------------------------------
+
+# increase history size
+set -g history-limit 100000
+
+# start with mouse mode enabled
+set -g mouse on
+
+# replace C-b by C-a instead of using both prefixes
+unbind C-a
+
+# -- tpm -----------------------------------------------------------------------
+
+tmux_conf_update_plugins_on_launch=true
+tmux_conf_update_plugins_on_reload=true
+
+# -- custom key bindings -------------------------------------------------------
+
+bind h split-window -v
+bind v split-window -h

--- a/home/shell.nix
+++ b/home/shell.nix
@@ -1,0 +1,61 @@
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.zsh-completions ];
+
+  programs.zsh = {
+    enable = true;
+
+    history = {
+      size = 100000;
+      save = 100000;
+      share = true;
+      extended = true;
+    };
+
+    sessionVariables = {
+      EDITOR = "emacs -nw";
+      VISUAL = "emacs";
+    };
+
+    initContent = ''
+      # Emacs keybind
+      bindkey -e
+
+      # Options
+      setopt notify
+      setopt extendedglob
+      setopt correct
+      setopt HIST_NO_STORE
+      setopt ignore_eof
+    '';
+
+    shellAliases = {
+      grep = "grep --color=auto";
+      ls = "ls --color=auto";
+      k = "kubectl";
+      ksec = "kubesec";
+      wk = "watch kubectl";
+    };
+
+    syntaxHighlighting.enable = true;
+    autosuggestion.enable = true;
+  };
+
+  programs.starship.enable = true;
+  programs.zoxide.enable = true;
+
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
+
+  programs.nix-index = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+}

--- a/home/tmux.nix
+++ b/home/tmux.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+let
+  # https://github.com/gpakosz/.tmux (fetched 2025-03-08)
+  gpakoszTmux = pkgs.fetchFromGitHub {
+    owner = "gpakosz";
+    repo = ".tmux";
+    rev = "af33f07134b76134acca9d01eacbdecca9c9cda6";
+    hash = "sha256-nXm664l84YSwZeRM4Hsweqgz+OlpyfwXcgEdyNGhaGA=";
+  };
+in
+{
+  home.packages = [ pkgs.tmux ];
+
+  home.file.".tmux.conf".source = "${gpakoszTmux}/.tmux.conf";
+  home.file.".tmux.conf.local".source = ./dotfiles/tmux/tmux.conf.local;
+}


### PR DESCRIPTION
## Summary

- Add `home/shell.nix`: zsh (options, aliases, syntax highlighting, autosuggestion), starship, zoxide, fzf, direnv with nix-direnv, nix-index
- Add `home/tmux.nix`: gpakosz/.tmux via `fetchFromGitHub`, tmux package, local `tmux.conf.local`
- Generate Claude Code `settings.json` via `builtins.toJSON` with `config.home.homeDirectory`
- Manage `statusline-command.sh` as executable dotfile
- Remove `fzf`, `zoxide`, `direnv` from `home.packages` (now managed via `programs.*` in shell.nix)

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| zsh-completions | `home.packages` | Completion definitions package, not a zsh plugin |
| Directory jumping | `programs.zoxide` | Nix-native z alternative, replaces zsh-z |
| Claude settings | `builtins.toJSON` | Dynamic path generation, no hardcoded home directory |
| gpakosz/.tmux | `fetchFromGitHub` + `home.file` | Simpler than flake input; "Worse is Better" |
| Prompt theme | Starship | Nix-native, lighter than Spaceship |

## Test plan

- [x] `nixfmt --check` passes
- [x] `nix flake check` passes (no deprecation warnings)
- [x] `nix eval .#nixosConfigurations.desktop-01.config.system.build.toplevel` succeeds
- [ ] `sudo nixos-rebuild switch --flake .#desktop-01` on NixOS machine
- [ ] Run `nix-index` to build command-not-found database after first apply

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
