### PR TITLE
Preserve Claude Code plugins across nixos-rebuild switch

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -71,20 +71,34 @@ in
   ];
 
   home.file.".claude/CLAUDE.md".source = ./dotfiles/claude/CLAUDE.md;
-  home.file.".claude/settings.json".text = builtins.toJSON {
-    enabledPlugins = {
-      "gopls-lsp@claude-plugins-official" = true;
-    };
-    alwaysThinkingEnabled = true;
-    env = {
-      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
-    };
-    teammateMode = "in-process";
-    statusLine = {
-      type = "command";
-      command = "sh ${config.home.homeDirectory}/.claude/statusline-command.sh";
-    };
-  };
+
+  home.activation.claudeSettings =
+    let
+      baseSettings = builtins.toJSON {
+        alwaysThinkingEnabled = true;
+        env = {
+          CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+        };
+        teammateMode = "in-process";
+        statusLine = {
+          type = "command";
+          command = "sh ${config.home.homeDirectory}/.claude/statusline-command.sh";
+        };
+      };
+    in
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      settings_file="${config.home.homeDirectory}/.claude/settings.json"
+      base_settings='${baseSettings}'
+      mkdir -p "$(dirname "$settings_file")"
+      if [ -f "$settings_file" ]; then
+        existing_plugins=$(${pkgs.jq}/bin/jq -c '.enabledPlugins // {}' "$settings_file")
+        echo "$base_settings" | ${pkgs.jq}/bin/jq --argjson plugins "$existing_plugins" '. + {enabledPlugins: $plugins}' > "$settings_file.tmp"
+        mv "$settings_file.tmp" "$settings_file"
+      else
+        echo "$base_settings" > "$settings_file"
+      fi
+    '';
+
   home.file.".claude/statusline-command.sh" = {
     source = ./dotfiles/claude/statusline-command.sh;
     executable = true;


### PR DESCRIPTION
## Summary
- Replace `home.file.".claude/settings.json"` with a Home Manager activation script that merges Nix-defined base settings with existing `enabledPlugins`
- Plugins added via the Claude Code UI are preserved across `nixos-rebuild switch`
- `settings.json` is now a regular file (not a read-only symlink), so Claude Code can edit it directly

## How it works
1. If `~/.claude/settings.json` exists → extract `enabledPlugins` with `jq`, merge with base settings
2. If it doesn't exist → write base settings as-is

## Test plan
- [ ] Run `nixos-rebuild switch` and verify `settings.json` is created with base settings
- [ ] Add a plugin via Claude Code UI, run `nixos-rebuild switch` again, and verify the plugin is preserved
- [ ] Verify `statusline-command.sh` still works

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
