### PR TITLE
Sync Claude Code enabledPlugins from installed_plugins.json

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -88,15 +88,20 @@ in
     in
     config.lib.dag.entryAfter [ "writeBoundary" ] ''
       settings_file="${config.home.homeDirectory}/.claude/settings.json"
+      installed_plugins_file="${config.home.homeDirectory}/.claude/plugins/installed_plugins.json"
       base_settings='${baseSettings}'
       mkdir -p "$(dirname "$settings_file")"
-      if [ -f "$settings_file" ]; then
-        existing_plugins=$(${pkgs.jq}/bin/jq -c '.enabledPlugins // {}' "$settings_file")
-        echo "$base_settings" | ${pkgs.jq}/bin/jq --argjson plugins "$existing_plugins" '. + {enabledPlugins: $plugins}' > "$settings_file.tmp"
-        mv "$settings_file.tmp" "$settings_file"
+
+      # Build enabledPlugins from installed_plugins.json
+      if [ -f "$installed_plugins_file" ]; then
+        installed_plugins=$(${pkgs.jq}/bin/jq -c '[.plugins // {} | keys[] | {(.): true}] | add // {}' "$installed_plugins_file")
       else
-        echo "$base_settings" > "$settings_file"
+        installed_plugins='{}'
       fi
+
+      # Merge base settings with installed plugins
+      echo "$base_settings" | ${pkgs.jq}/bin/jq --argjson plugins "$installed_plugins" '. + {enabledPlugins: $plugins}' > "$settings_file.tmp"
+      mv "$settings_file.tmp" "$settings_file"
     '';
 
   home.file.".claude/statusline-command.sh" = {


### PR DESCRIPTION
## Summary
- Fix activation script to derive `enabledPlugins` from `installed_plugins.json` instead of only preserving existing entries
- Plugins installed via `/plugin install` are now automatically enabled after `nixos-rebuild switch`

## Background
Previously, the activation script preserved `enabledPlugins` already present in `settings.json`, but did not sync with `installed_plugins.json`. This caused plugins to appear as "installed" but not be recognized in new sessions.

## Test plan
- [ ] Run `nixos-rebuild switch` and verify `settings.json` contains all plugins from `installed_plugins.json`
- [ ] Install a new plugin via `/plugin install`, run `nixos-rebuild switch`, and confirm it appears in `enabledPlugins`
- [ ] Uninstall a plugin via `/plugin uninstall`, run `nixos-rebuild switch`, and confirm it is removed from `enabledPlugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
