### PR TITLE
Add Cursor editor to home packages

### DIFF
--- a/home/editors.nix
+++ b/home/editors.nix
@@ -1,5 +1,9 @@
 { pkgs, ... }:
 {
+  home.packages = [
+    pkgs.code-cursor
+  ];
+
   programs.vscode = {
     enable = true;
     package = pkgs.vscode;


### PR DESCRIPTION
## Summary
- Add `pkgs.code-cursor` to `home.packages` in `home/editors.nix`
- Cursor is an AI-powered code editor built on VS Code, available in nixpkgs-unstable
- Wayland support is already handled by `NIXOS_OZONE_WL=1` in `modules/nvidia.nix`

Closes #37

## Test plan
- [ ] `nix fmt` passes
- [ ] `nix flake check` passes
- [ ] On NixOS machine: `nixos-rebuild switch` installs Cursor and it launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
