### PR TITLE
Add pavucontrol for audio device switching via Waybar

### DIFF
--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -1,5 +1,7 @@
-{ ... }:
+{ pkgs, ... }:
 {
+  home.packages = [ pkgs.pavucontrol ];
+
   programs.waybar = {
     enable = true;
     settings = {
@@ -44,6 +46,7 @@
             ];
           };
           on-click = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+          on-click-right = "pavucontrol";
         };
 
         bluetooth = {


### PR DESCRIPTION
## Summary
- Install pavucontrol (PulseAudio Volume Control) via `home.packages`
- Configure Waybar's pulseaudio module to launch pavucontrol on right-click
- Enables easy audio input/output device switching for Bluetooth headphones

Closes #56

## Test plan
- [ ] `nix fmt` passes (verified locally)
- [ ] `nix flake check` passes (verified locally)
- [ ] `nixos-rebuild switch` applies successfully on NixOS machine
- [ ] Right-clicking Waybar's volume icon launches pavucontrol
- [ ] pavucontrol "Output Devices" tab shows and switches output devices
- [ ] pavucontrol "Input Devices" tab shows and switches input devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
