### PR TITLE
Enable uwsm for Hyprland session management

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -2,6 +2,7 @@
 {
   wayland.windowManager.hyprland = {
     enable = true;
+    systemd.enable = false;
     settings = {
       # Monitor layout (left to right): JAPANNEXT 2K → DELL 2K → LG 4K
       monitor = [

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -2,13 +2,14 @@
 {
   # Hyprland
   programs.hyprland.enable = true;
+  programs.hyprland.withUWSM = true;
 
   # Login manager
   services.greetd = {
     enable = true;
     settings = {
       default_session = {
-        command = "${pkgs.tuigreet}/bin/tuigreet --time --cmd Hyprland";
+        command = "${pkgs.tuigreet}/bin/tuigreet --time --cmd start-hyprland";
         user = "greeter";
       };
     };


### PR DESCRIPTION
## Summary
- Enable `programs.hyprland.withUWSM = true` to use uwsm (Universal Wayland Session Manager)
- Change tuigreet login command from `Hyprland` to `start-hyprland` for uwsm-based startup
- Disable Home Manager's `systemd.enable` to prevent conflict with uwsm's session management

## Test plan
- [ ] `nix fmt` passes (verified locally)
- [ ] `nixos-rebuild switch` succeeds on NixOS machine
- [ ] Login via tuigreet works with `start-hyprland`
- [ ] No warning popup about running Hyprland without start-hyprland
- [ ] waybar, blueman-applet, and other exec-once apps launch correctly
- [ ] Multi-monitor layout, keybindings, and logout/login cycle work as expected

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
