### PR TITLE
Enable NVIDIA VA-API hardware video decode for browsers

### DIFF
--- a/home/browsers.nix
+++ b/home/browsers.nix
@@ -1,8 +1,17 @@
 { pkgs, ... }:
 {
-  programs.firefox.enable = true;
+  programs.firefox = {
+    enable = true;
+    policies.Preferences = {
+      "media.ffmpeg.vaapi.enabled" = true;
+    };
+  };
 
   home.packages = [
-    pkgs.google-chrome
+    (pkgs.google-chrome.override {
+      commandLineArgs = [
+        "--enable-features=VaapiVideoDecodeLinuxGL"
+      ];
+    })
   ];
 }

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 {
   # NVIDIA proprietary driver
   hardware.nvidia = {
@@ -7,15 +7,20 @@
     package = config.boot.kernelPackages.nvidiaPackages.stable;
   };
 
-  # OpenGL
-  hardware.graphics.enable = true;
+  # OpenGL & VA-API hardware video decode
+  hardware.graphics = {
+    enable = true;
+    extraPackages = [ pkgs.nvidia-vaapi-driver ];
+  };
 
   # Load nvidia driver for Xorg and Wayland
   services.xserver.videoDrivers = [ "nvidia" ];
 
-  # Wayland-specific environment variables
+  # Wayland & VA-API environment variables
   environment.sessionVariables = {
     NIXOS_OZONE_WL = "1";
     WLR_NO_HARDWARE_CURSORS = "1";
+    LIBVA_DRIVER_NAME = "nvidia";
+    NVD_BACKEND = "direct";
   };
 }


### PR DESCRIPTION
## Summary
- Add `nvidia-vaapi-driver` to `hardware.graphics.extraPackages` and set `LIBVA_DRIVER_NAME`/`NVD_BACKEND` session variables for system-level VA-API support
- Enable Firefox hardware decode via `policies.Preferences` (`media.ffmpeg.vaapi.enabled`)
- Add `--enable-features=VaapiVideoDecodeLinuxGL` flag to Chrome via package override

## Test plan
- [ ] `vainfo` で NVIDIA VA-API ドライバがロードされることを確認
- [ ] Firefox `about:support` → Media セクションで hardware decode 有効を確認
- [ ] Chrome `chrome://gpu` で "Video Decode: Hardware accelerated" を確認
- [ ] YouTube 1080p VP9 動画が鮮明に再生されることを確認

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
