### PR TITLE
Fix aqua shim directory missing from zsh PATH

### DIFF
--- a/home/shell.nix
+++ b/home/shell.nix
@@ -18,6 +18,9 @@
     };
 
     initContent = ''
+      # aqua - add shim directory to PATH
+      export PATH="''${AQUA_ROOT_DIR:-''${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+
       # Emacs keybind
       bindkey -e
 


### PR DESCRIPTION
## Summary

- Add aqua's shim directory (`~/.local/share/aquaproj-aqua/bin`) to zsh PATH in `home/shell.nix`
- This was missed during the dotfiles-to-Home-Manager migration (#58), where `dot_zsh.d/path.zsh` contained `$(aqua root-dir)/bin` but was not carried over
- Without this, aqua-managed tools (`gitleaks`, `lefthook`) were not found by the shell, silently disabling pre-commit hooks

## Test plan

- [ ] `sudo nixos-rebuild switch --flake .#desktop-01`
- [ ] Open a new terminal and verify `which gitleaks` and `which lefthook` resolve
- [ ] Run `lefthook install` in the repo, then verify pre-commit hook triggers on `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
