### PR TITLE
Fix Firefox VA-API hardware video decode on NVIDIA

### DIFF
--- a/home/browsers.nix
+++ b/home/browsers.nix
@@ -4,6 +4,9 @@
     enable = true;
     policies.Preferences = {
       "media.ffmpeg.vaapi.enabled" = true;
+      "media.hardware-video-decoding.force-enabled" = true;
+      "media.rdd-ffmpeg.enabled" = true;
+      "widget.dmabuf.force-enabled" = true;
     };
   };
 

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -22,5 +22,6 @@
     WLR_NO_HARDWARE_CURSORS = "1";
     LIBVA_DRIVER_NAME = "nvidia";
     NVD_BACKEND = "direct";
+    MOZ_DISABLE_RDD_SANDBOX = "1";
   };
 }


### PR DESCRIPTION
## Summary

- Add Firefox policy preferences to bypass gfxInfo blocklist and enable VA-API decode path (`media.hardware-video-decoding.force-enabled`, `media.rdd-ffmpeg.enabled`, `widget.dmabuf.force-enabled`)
- Add `MOZ_DISABLE_RDD_SANDBOX=1` environment variable to allow RDD process GPU access

PR #66 configured nvidia-vaapi-driver and basic preferences, but Firefox's internal blocklist (`FEATURE_HARDWARE_VIDEO_DECODING_NO_LINUX_NVIDIA`) and RDD sandbox prevented actual hardware decoding.

## Verification

- `vainfo`: VP9/AV1/H264 profiles confirmed
- Firefox `about:support`: `HARDWARE_VIDEO_DECODING` = `force_enabled`
- `MOZ_LOG` output: continuous `FFVPX: VA-API frame` in RDD process
- Chrome `chrome://gpu`: Video Decode = Hardware accelerated
- Both browsers load `nvidia_drv_video.so` and `libva` in their decode processes

## Test plan

- [ ] `sudo nixos-rebuild switch --flake .#desktop-01`
- [ ] Re-login (for `MOZ_DISABLE_RDD_SANDBOX` env var)
- [ ] Firefox: YouTube 1080p video plays without blurriness
- [ ] Chrome: YouTube 1080p video plays without blurriness
- [ ] Chrome: no `vaEndPicture failed` errors in stderr

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
