### PR TITLE
Add Mac-like copy/paste keybindings using xremap

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1766774972,
+        "narHash": "sha256-8qxEFpj4dVmIuPn9j9z6NTbU+hrcGjBOvaxTzre5HmM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "01bc1d404a51a0a07e9d8759cd50a7903e218c82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -56,12 +89,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
-        "sops-nix": "sops-nix"
+        "sops-nix": "sops-nix",
+        "xremap-flake": "xremap-flake"
       }
     },
     "sops-nix": {
@@ -81,6 +130,46 @@
       "original": {
         "owner": "Mic92",
         "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "xremap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771790974,
+        "narHash": "sha256-hXbCEdWcpOvHsFIE7pQw3evqPjqXJhEYBCBJKoGVzJQ=",
+        "owner": "k0kubun",
+        "repo": "xremap",
+        "rev": "a2fc6caa0c7d35d87d130437dc4a4582a3908871",
+        "type": "github"
+      },
+      "original": {
+        "owner": "k0kubun",
+        "ref": "v0.14.15",
+        "repo": "xremap",
+        "type": "github"
+      }
+    },
+    "xremap-flake": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "xremap": "xremap"
+      },
+      "locked": {
+        "lastModified": 1771968045,
+        "narHash": "sha256-BK2Zcio1gBMTIjIV2MfULqgxv21Y4S9HbgzGuI4AzSc=",
+        "owner": "xremap",
+        "repo": "nix-flake",
+        "rev": "b89f36dd4a0a68d904a4995e3156f0ac758fcdd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "xremap",
+        "repo": "nix-flake",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    xremap-flake = {
+      url = "github:xremap/nix-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -23,6 +27,7 @@
       home-manager,
       sops-nix,
       nix-index-database,
+      xremap-flake,
       ...
     }:
     let
@@ -34,6 +39,7 @@
         modules = [
           ./hosts/desktop-01
           sops-nix.nixosModules.sops
+          xremap-flake.nixosModules.default
           home-manager.nixosModules.home-manager
           {
             home-manager.useGlobalPkgs = true;

--- a/home/dotfiles/tmux/tmux.conf.local
+++ b/home/dotfiles/tmux/tmux.conf.local
@@ -242,6 +242,9 @@ set -g history-limit 100000
 # start with mouse mode enabled
 set -g mouse on
 
+# Wayland clipboard integration (tmux 3.2+)
+set -s copy-command 'wl-copy'
+
 # replace C-b by C-a instead of using both prefixes
 unbind C-a
 

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -32,12 +32,17 @@
         ", XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
       ];
 
+      bindm = [
+        "$mod, mouse:272, movewindow"
+        "$mod, mouse:273, resizewindow"
+      ];
+
       bind = [
         "$mod, D, exec, wofi --show drun"
         "$mod, Return, exec, $terminal"
-        "$mod, Q, killactive"
+        "$mod, W, killactive"
         "$mod, M, exit"
-        "$mod, V, togglefloating"
+        "$mod, T, togglefloating"
         "$mod, F, fullscreen"
 
         # Move focus

--- a/home/tmux.nix
+++ b/home/tmux.nix
@@ -9,7 +9,10 @@ let
   };
 in
 {
-  home.packages = [ pkgs.tmux ];
+  home.packages = [
+    pkgs.tmux
+    pkgs.wl-clipboard
+  ];
 
   home.file.".tmux.conf".source = "${gpakoszTmux}/.tmux.conf";
   home.file.".tmux.conf.local".source = ./dotfiles/tmux/tmux.conf.local;

--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -12,6 +12,7 @@
     ../../modules/audio.nix
     ../../modules/bluetooth.nix
     ../../modules/ssh.nix
+    ../../modules/xremap.nix
   ];
 
   # Bootloader

--- a/modules/xremap.nix
+++ b/modules/xremap.nix
@@ -1,0 +1,27 @@
+{ ... }:
+{
+  services.xremap = {
+    enable = true;
+    withHypr = true;
+    serviceMode = "user";
+    userName = "aoshima";
+    config.keymap = [
+      {
+        name = "Terminal: Super+C/V to Ctrl+Shift+C/V";
+        application.only = [ "com.mitchellh.ghostty" ];
+        remap = {
+          "Super-c" = "C-Shift-c";
+          "Super-v" = "C-Shift-v";
+        };
+      }
+      {
+        name = "GUI: Super+C/V to Ctrl+C/V";
+        application.not = [ "com.mitchellh.ghostty" ];
+        remap = {
+          "Super-c" = "C-c";
+          "Super-v" = "C-v";
+        };
+      }
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Introduce xremap (via nix-flake) to remap Super+C/V → Ctrl+C/V (GUI) / Ctrl+Shift+C/V (terminal), enabling Mac-like copy/paste across macOS and NixOS
- Reassign conflicting Hyprland keybinds: Super+Q→W (killactive), Super+V→T (togglefloating)
- Add Super+mouse drag bindings for window move/resize
- Add wl-clipboard + tmux `copy-command` for Wayland clipboard integration

## Test plan

- [ ] `nix flake check` passes (CI)
- [ ] `nixos-rebuild switch` succeeds on desktop-01
- [ ] Super+C/V copies/pastes in GUI apps (e.g. Firefox)
- [ ] Super+C/V copies/pastes in ghostty without sending SIGINT
- [ ] Clipboard shared between apps (copy in terminal, paste in browser)
- [ ] tmux copy mode sends to system clipboard via wl-copy
- [ ] Super+W closes active window
- [ ] Super+T toggles floating
- [ ] Super+left-drag moves window, Super+right-drag resizes window
- [ ] Verify ghostty app_id with `hyprctl clients` (expected: `com.mitchellh.ghostty`)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
