### PR TITLE
Add gnome-keyring for VS Code Secret Service API support

### DIFF
--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -13,6 +13,7 @@
     ../../modules/bluetooth.nix
     ../../modules/ssh.nix
     ../../modules/xremap.nix
+    ../../modules/keyring.nix
   ];
 
   # Bootloader

--- a/modules/keyring.nix
+++ b/modules/keyring.nix
@@ -1,0 +1,5 @@
+{ ... }:
+{
+  services.gnome.gnome-keyring.enable = true;
+  security.pam.services.greetd.enableGnomeKeyring = true;
+}


### PR DESCRIPTION
## Summary
- Add `modules/keyring.nix` enabling gnome-keyring daemon and greetd PAM integration
- Import the new module in `hosts/desktop-01/default.nix`
- Resolves VS Code "OS keyring couldn't be identified" warning on Hyprland

## Verification
- [x] `nix fmt` passes
- [x] `nix flake check` passes
- [ ] `nixos-rebuild switch` on NixOS machine
- [ ] VS Code launches without keyring warning
- [ ] VS Code Settings Sync / GitHub Copilot auth persists across restarts

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
