### PR TITLE
Assign workspaces to monitors in round-robin pattern

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -11,6 +11,19 @@
         "DP-8, 3840x2160@60, 5120x0, 1.5" # LG HDR 4K (right)
       ];
 
+      # Workspace-to-monitor assignment (round-robin: left → center → right)
+      workspace = [
+        "1, monitor:DP-6, default:true"
+        "2, monitor:DP-9, default:true"
+        "3, monitor:DP-8, default:true"
+        "4, monitor:DP-6"
+        "5, monitor:DP-9"
+        "6, monitor:DP-8"
+        "7, monitor:DP-6"
+        "8, monitor:DP-9"
+        "9, monitor:DP-8"
+      ];
+
       input = {
         kb_layout = "us";
         kb_variant = "dvorak";


### PR DESCRIPTION
## Summary
- Add explicit workspace-to-monitor mappings in Hyprland config (round-robin: left → center → right)
- Workspaces 1,4,7 → DP-6 (JAPANNEXT), 2,5,8 → DP-9 (DELL), 3,6,9 → DP-8 (LG)
- Default workspaces 1,2,3 appear on their assigned monitors at startup

Closes #73

## Test plan
- [ ] Run `nixos-rebuild switch --flake .#desktop-01` on the NixOS machine
- [ ] Verify workspaces 1, 2, 3 appear on left, center, right monitors at startup
- [ ] Verify Super+4 through Super+9 open on the correct monitors
- [ ] Verify workspaces can still be freely moved between monitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
