### PR TITLE
Fix freelens not appearing in wofi launcher

### DIFF
--- a/pkgs/freelens.nix
+++ b/pkgs/freelens.nix
@@ -11,9 +11,18 @@ let
     url = "https://github.com/freelensapp/freelens/releases/download/v${version}/Freelens-${version}-linux-amd64.AppImage";
     hash = "sha256-Goe/eAmefL+4itHrGmQjBGVWalk559kGg/OgA1yKKdk=";
   };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/freelens.desktop $out/share/applications/freelens.desktop
+    install -Dm444 ${appimageContents}/freelens.png $out/share/pixmaps/freelens.png
+    substituteInPlace $out/share/applications/freelens.desktop \
+      --replace-warn 'Exec=AppRun' 'Exec=freelens'
+  '';
 
   meta = {
     description = "Open-source Kubernetes IDE";


### PR DESCRIPTION
## Summary
- Add `.desktop` file and icon installation to the freelens AppImage package
- Extract AppImage contents using `appimageTools.extractType2` and install desktop entry and icon via `extraInstallCommands`
- Fix `Exec=AppRun` to `Exec=freelens` in the desktop entry to match the Nix-wrapped binary name

## Test plan
- [ ] Run `nixos-rebuild switch --flake .#desktop-01`
- [ ] Verify freelens appears in wofi launcher
- [ ] Verify freelens launches correctly from wofi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
