### PR TITLE
Enable natural scroll in Hyprland

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -27,6 +27,7 @@
       input = {
         kb_layout = "us";
         kb_variant = "dvorak";
+        natural_scroll = true;
       };
 
       exec-once = [


### PR DESCRIPTION
## Summary
- Enable natural scroll (reverse scroll direction) in Hyprland input settings for MX Ergo trackball

## Test plan
- [ ] Run `sudo nixos-rebuild switch --flake .#desktop-01` on NixOS machine
- [ ] Verify scroll direction is reversed (natural scroll behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
