### PR TITLE
Simplify workspace navigation to monitor-based focus switching

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -1,4 +1,11 @@
-{ ... }:
+{ pkgs, ... }:
+let
+  closeAllWindows = pkgs.writeShellScript "hypr-close-all-windows" ''
+    ws=$(hyprctl activeworkspace -j | jq '.id')
+    hyprctl clients -j | jq -r ".[] | select(.workspace.id == $ws) | .address" \
+      | xargs -I{} hyprctl dispatch closewindow address:{}
+  '';
+in
 {
   wayland.windowManager.hyprland = {
     enable = true;
@@ -65,27 +72,22 @@
         "$mod, K, movefocus, u"
         "$mod, J, movefocus, d"
 
-        # Workspaces
-        "$mod, 1, workspace, 1"
-        "$mod, 2, workspace, 2"
-        "$mod, 3, workspace, 3"
-        "$mod, 4, workspace, 4"
-        "$mod, 5, workspace, 5"
-        "$mod, 6, workspace, 6"
-        "$mod, 7, workspace, 7"
-        "$mod, 8, workspace, 8"
-        "$mod, 9, workspace, 9"
+        # Focus monitor
+        "$mod, 1, focusmonitor, DP-6" # left
+        "$mod, 2, focusmonitor, DP-9" # center
+        "$mod, 3, focusmonitor, DP-8" # right
 
-        # Move window to workspace
-        "$mod SHIFT, 1, movetoworkspace, 1"
-        "$mod SHIFT, 2, movetoworkspace, 2"
-        "$mod SHIFT, 3, movetoworkspace, 3"
-        "$mod SHIFT, 4, movetoworkspace, 4"
-        "$mod SHIFT, 5, movetoworkspace, 5"
-        "$mod SHIFT, 6, movetoworkspace, 6"
-        "$mod SHIFT, 7, movetoworkspace, 7"
-        "$mod SHIFT, 8, movetoworkspace, 8"
-        "$mod SHIFT, 9, movetoworkspace, 9"
+        # Move window to monitor
+        "$mod SHIFT, 1, movewindow, mon:DP-6" # left
+        "$mod SHIFT, 2, movewindow, mon:DP-9" # center
+        "$mod SHIFT, 3, movewindow, mon:DP-8" # right
+
+        # Close all windows on active workspace
+        "$mod SHIFT, W, exec, ${closeAllWindows}"
+
+        # Cycle windows on active monitor
+        "CTRL, Right, cyclenext"
+        "CTRL, Left, cyclenext, prev"
       ];
     };
   };


### PR DESCRIPTION
## Summary
- Replace Super+1-9 workspace switching with Super+1-3 monitor focus (`focusmonitor`)
- Add Super+Shift+1-3 to move windows between monitors (`movewindow mon:`)
- Add Ctrl+Left/Right for per-monitor window cycling (`cyclenext`)
- Add Super+Shift+W to close all windows on the active workspace

Closes #81

## Changes
- `home/hyprland.nix`: Replace workspace-based keybindings with monitor-based focus model, add window cycling and close-all-windows script

## Test Plan
- [ ] Super+1 focuses DP-6 (left monitor)
- [ ] Super+2 focuses DP-9 (center monitor)
- [ ] Super+3 focuses DP-8 (right monitor)
- [ ] Super+4-9 do nothing
- [ ] Ctrl+Right cycles to next window on active monitor
- [ ] Ctrl+Left cycles to previous window on active monitor
- [ ] Super+Shift+1-3 moves active window to corresponding monitor
- [ ] Super+Shift+W closes all windows on active workspace
- [ ] Super+W still closes single active window
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
