### PR TITLE
Refine Hyprland keybindings for workspace and window management

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -82,12 +82,19 @@ in
         "$mod SHIFT, 2, movewindow, mon:DP-9" # center
         "$mod SHIFT, 3, movewindow, mon:DP-8" # right
 
-        # Close all windows on active workspace
+        # Cycle windows on active workspace
+        "$mod, Tab, cyclenext"
+        "$mod SHIFT, Tab, cyclenext, prev"
+
+        # Cycle workspaces on active monitor
+        "CTRL, Right, workspace, m+1"
+        "CTRL, Left, workspace, m-1"
+
+        # Delete workspace (close all windows)
         "$mod SHIFT, W, exec, ${closeAllWindows}"
 
-        # Cycle windows on active monitor
-        "CTRL, Right, cyclenext"
-        "CTRL, Left, cyclenext, prev"
+        # Add empty workspace on current monitor
+        "$mod SHIFT, N, workspace, emptym"
       ];
     };
   };


### PR DESCRIPTION
## Summary
- Add `Super+Tab` / `Super+Shift+Tab` for cycling windows within the active workspace
- Change `Ctrl+Left/Right` from window cycling to workspace cycling on the active monitor (`m+1`/`m-1`)
- Add `Super+Shift+N` to create an empty workspace on the current monitor (`emptym`)
- Keep `Super+Shift+W` for deleting workspace (close all windows)

## Keybinding Changes

| Keybinding | Before | After |
|---|---|---|
| `Super+Tab` | (none) | Cycle windows clockwise |
| `Super+Shift+Tab` | (none) | Cycle windows counter-clockwise |
| `Ctrl+Right` | `cyclenext` | `workspace, m+1` |
| `Ctrl+Left` | `cyclenext, prev` | `workspace, m-1` |
| `Super+Shift+N` | (none) | `workspace, emptym` |
| `Super+Shift+W` | Close all windows | Close all windows (unchanged) |

## Test plan
- [ ] Super+Tab cycles to the next window in the active workspace
- [ ] Super+Shift+Tab cycles to the previous window
- [ ] Ctrl+Right switches to the next workspace on the current monitor
- [ ] Ctrl+Left switches to the previous workspace on the current monitor
- [ ] Super+Shift+N creates/switches to an empty workspace on the current monitor
- [ ] Super+Shift+W closes all windows on the active workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
