### PR TITLE
Add MX Ergo mouse button bindings for workspace navigation

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -89,6 +89,8 @@ in
         # Cycle workspaces on active monitor
         "CTRL, Right, workspace, m+1"
         "CTRL, Left, workspace, m-1"
+        ", mouse:276, workspace, m+1" # MX Ergo forward button
+        ", mouse:275, workspace, m-1" # MX Ergo back button
 
         # Delete workspace (close all windows)
         "$mod SHIFT, W, exec, ${closeAllWindows}"


### PR DESCRIPTION
## Summary
- Map MX Ergo forward button (mouse:276) to cycle to next workspace on active monitor (`m+1`)
- Map MX Ergo back button (mouse:275) to cycle to previous workspace on active monitor (`m-1`)
- Matches existing `CTRL+Right`/`CTRL+Left` keyboard bindings

## Test plan
- [ ] Apply config with `sudo nixos-rebuild switch --flake .#desktop-01`
- [ ] Press forward button (left of left-click, bottom) → workspace moves right
- [ ] Press back button (left of left-click, top) → workspace moves left
- [ ] Verify existing keyboard shortcuts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
