### PR TITLE
Add Waybar styling with blur and app icon workspaces

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -43,6 +43,16 @@ in
         "blueman-applet"
       ];
 
+      decoration.blur = {
+        enabled = true;
+        size = 5;
+        passes = 2;
+      };
+
+      layerrule = [
+        "blur on, match:namespace waybar"
+      ];
+
       "$mod" = "SUPER";
       "$terminal" = "ghostty";
 

--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -4,6 +4,49 @@
 
   programs.waybar = {
     enable = true;
+
+    style = ''
+      * {
+        font-family: "JetBrainsMono Nerd Font", monospace;
+        font-size: 13px;
+        min-height: 0;
+      }
+
+      window#waybar {
+        background: rgba(30, 30, 46, 0.85);
+        color: #cdd6f4;
+      }
+
+      #workspaces button {
+        padding: 0 10px;
+        min-width: 24px;
+        color: #a6adc8;
+        background: rgba(69, 71, 90, 0.5);
+        margin: 4px 2px;
+        border-radius: 4px;
+        border: none;
+      }
+
+      #workspaces button.visible {
+        color: #cdd6f4;
+        border-bottom: 2px solid #585b70;
+      }
+
+      #workspaces button.active {
+        color: #cdd6f4;
+        background: rgba(137, 180, 250, 0.25);
+        border-bottom: 2px solid #89b4fa;
+      }
+
+      #clock,
+      #network,
+      #pulseaudio,
+      #bluetooth,
+      #tray {
+        padding: 0 10px;
+      }
+    '';
+
     settings = {
       mainBar = {
         layer = "top";
@@ -20,7 +63,24 @@
         ];
 
         "hyprland/workspaces" = {
-          format = "{id}";
+          format = "{windows}";
+          format-window-separator = " ";
+          window-rewrite-default = "󰏗";
+          window-rewrite = {
+            "com.mitchellh.ghostty" = "󰆍";
+            "firefox" = "󰈹";
+            "google-chrome" = "󰊯";
+            "chromium" = "󰊯";
+            "code" = "󰨞";
+            "Bitwarden" = "󰌋";
+            "Freelens" = "󰠳";
+            "discord" = "󰙯";
+            "slack" = "󰒱";
+            "nautilus" = "󰉋";
+            "thunar" = "󰉋";
+            "spotify" = "󰓇";
+            "obsidian" = "󱓧";
+          };
         };
 
         clock = {


### PR DESCRIPTION
## Summary
- Add Catppuccin Mocha-based CSS styling for Waybar (semi-transparent dark background, clean typography)
- Enable Hyprland blur effect on Waybar using the new 0.53+ `layerrule` syntax
- Replace workspace numbers with app icons via `window-rewrite` rules using Nerd Font MDI glyphs
- Add chip-style workspace buttons with 3-state visual indicators (active/visible/inactive)

## Test plan
- [ ] Run `nixos-rebuild switch --flake .#desktop-01` on the NixOS machine
- [ ] Verify Waybar blur effect renders correctly
- [ ] Verify app icons appear for Ghostty, Firefox, Slack, Bitwarden, Freelens
- [ ] Verify active workspace (focused monitor) shows blue underline + blue background
- [ ] Verify visible workspaces (other monitors) show gray underline
- [ ] Verify inactive workspaces have chip-style gray background with clear separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
