### PR TITLE
Replace wofi with rofi-wayland and add clipboard history via cliphist

### DIFF
--- a/home/cliphist.nix
+++ b/home/cliphist.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  services.cliphist.enable = true;
+}

--- a/home/default.nix
+++ b/home/default.nix
@@ -8,7 +8,8 @@ in
     ./browsers.nix
     ./hyprland.nix
     ./fcitx5.nix
-    ./wofi.nix
+    ./rofi.nix
+    ./cliphist.nix
     ./waybar.nix
     ./editors.nix
     ./mako.nix

--- a/home/dotfiles/rofi/nord.rasi
+++ b/home/dotfiles/rofi/nord.rasi
@@ -1,0 +1,69 @@
+* {
+    nord0:  #2e3440;
+    nord1:  #3b4252;
+    nord2:  #434c5e;
+    nord3:  #4c566a;
+    nord4:  #d8dee9;
+    nord5:  #e5e9f0;
+    nord6:  #eceff4;
+    nord8:  #88c0d0;
+    nord9:  #81a1c1;
+    nord11: #bf616a;
+
+    background-color: transparent;
+    text-color:       @nord4;
+}
+
+window {
+    background-color: @nord0;
+    border:           2px;
+    border-color:     @nord9;
+    border-radius:    8px;
+    padding:          0;
+    width:            600px;
+}
+
+mainbox {
+    padding:  0;
+    children: [ inputbar, listview ];
+}
+
+inputbar {
+    background-color: @nord1;
+    padding:          8px 12px;
+    children:         [ prompt, entry ];
+    spacing:          8px;
+}
+
+prompt {
+    text-color: @nord8;
+}
+
+entry {
+    placeholder:       "Search...";
+    placeholder-color: @nord3;
+}
+
+listview {
+    lines:    8;
+    padding:  4px 0;
+    scrollbar: false;
+}
+
+element {
+    padding: 8px 12px;
+}
+
+element selected.normal {
+    background-color: @nord2;
+    text-color:       @nord8;
+}
+
+element-text {
+    text-color: inherit;
+}
+
+element-icon {
+    size: 24px;
+    padding: 0 8px 0 0;
+}

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -69,7 +69,8 @@ in
       ];
 
       bind = [
-        "$mod, D, exec, wofi --show drun"
+        "$mod, D, exec, rofi -show drun -show-icons"
+        "$mod, V, exec, cliphist list | rofi -dmenu | cliphist decode | wl-copy"
         "$mod, Return, exec, $terminal"
         "$mod, W, killactive"
         "$mod, M, exit"

--- a/home/rofi.nix
+++ b/home/rofi.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  programs.rofi = {
+    enable = true;
+    package = pkgs.rofi;
+    terminal = "ghostty";
+    theme = ./dotfiles/rofi/nord.rasi;
+  };
+}

--- a/home/wofi.nix
+++ b/home/wofi.nix
@@ -1,4 +1,0 @@
-{ ... }:
-{
-  programs.wofi.enable = true;
-}


### PR DESCRIPTION
## Summary
- Replace wofi with rofi (Wayland-native, Nord theme) as the application launcher
- Add cliphist for clipboard history management (text + image)
- Update keybindings: Super+D for rofi drun, Super+V for clipboard history

Closes #85

## Changes
- `home/wofi.nix` — Deleted (wofi fully removed)
- `home/rofi.nix` — New file: enable rofi with `pkgs.rofi` (rofi-wayland merged into rofi in nixpkgs unstable), ghostty as terminal, Nord theme
- `home/dotfiles/rofi/nord.rasi` — New file: Nord color scheme theme for rofi
- `home/cliphist.nix` — New file: enable cliphist systemd service (wl-paste watchers for text and image)
- `home/default.nix` — Replace `./wofi.nix` import with `./rofi.nix` and `./cliphist.nix`
- `home/hyprland.nix` — Update Super+D to `rofi -show drun -show-icons`, add Super+V for clipboard history via `cliphist list | rofi -dmenu | cliphist decode | wl-copy`

## Test Plan
- [ ] `nix flake check` passes (verified locally)
- [ ] `Super+D` launches rofi in drun mode with Nord theme and app icons
- [ ] `Super+V` opens clipboard history via rofi and pastes selected entry
- [ ] Clipboard captures both text and image entries after login
- [ ] wofi is no longer installed or referenced
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
