### PR TITLE
Fix xremap Super+C/V for Dvorak keyboard layout

### DIFF
--- a/modules/xremap.nix
+++ b/modules/xremap.nix
@@ -5,21 +5,26 @@
     withHypr = true;
     serviceMode = "user";
     userName = "aoshima";
+    # xremap operates at the evdev level (keycodes), but Hyprland applies the
+    # Dvorak layout AFTER xremap's output. Output keycodes must be reverse-mapped
+    # through Dvorak so the application receives the correct keysyms:
+    #   KEY_I   → Dvorak → keysym 'c'
+    #   KEY_DOT → Dvorak → keysym 'v'
     config.keymap = [
       {
         name = "Terminal: Super+C/V to Ctrl+Shift+C/V";
         application.only = [ "com.mitchellh.ghostty" ];
         remap = {
-          "Super-c" = "C-Shift-c";
-          "Super-v" = "C-Shift-v";
+          "Super-c" = "C-Shift-i";
+          "Super-v" = "C-Shift-dot";
         };
       }
       {
         name = "GUI: Super+C/V to Ctrl+C/V";
         application.not = [ "com.mitchellh.ghostty" ];
         remap = {
-          "Super-c" = "C-c";
-          "Super-v" = "C-v";
+          "Super-c" = "C-i";
+          "Super-v" = "C-dot";
         };
       }
     ];


### PR DESCRIPTION
## Summary
- Fix xremap key remapping output to account for US Dvorak keyboard layout
- xremap operates at the evdev level (keycodes), but Hyprland applies Dvorak at the compositor level — output keycodes must be reverse-mapped so applications receive correct keysyms

Closes #86

## Changes
- `modules/xremap.nix`: Change remap output key names to Dvorak-compatible keycodes
  - `C-c` → `C-i` (KEY_I → Dvorak → keysym 'c')
  - `C-v` → `C-dot` (KEY_DOT → Dvorak → keysym 'v')
  - Same adjustment for Ctrl+Shift variants (Ghostty terminal)

## Test Plan
- [x] `nix fmt -- --check` passes
- [x] `nix flake check` passes
- [ ] Super+C copies selected text in Firefox
- [ ] Super+V pastes clipboard content in Firefox
- [ ] Super+C copies in Ghostty (Ctrl+Shift+C equivalent)
- [ ] Super+V pastes in Ghostty (Ctrl+Shift+V equivalent)
- [ ] Verify xremap service is running: `systemctl --user status xremap`

> **Note:** If Super+C/V still doesn't work after applying, verify xremap is running with `systemctl --user status xremap`. The service may need the user to be in the `input` group.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
