### PR TITLE
Pin GitHub Actions to SHA digests and extend Renovate for Actions/aqua

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,19 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - run: nix fmt -- --check .
 
   secrets:
     name: Secret detection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: aquaproj/aqua-installer@v3.1.1
+      - uses: aquaproj/aqua-installer@e2d0136abcf70b7a2f6f505720640750557c4b33 # v3.1.1
         with:
           aqua_version: v2.45.0
       - run: gitleaks detect
@@ -35,7 +35,7 @@ jobs:
     name: NixOS config check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - run: nix flake check
       - run: nix eval .#nixosConfigurations.desktop-01.config.system.build.toplevel

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"]
 }


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions references in CI workflow to SHA digests for supply chain security
- Add `helpers:pinGitHubActionDigests` preset to Renovate config for automatic SHA pin maintenance
- Renovate's `aqua` manager (enabled by default) covers aqua dependency updates

Closes #89

## Changes
- `.github/workflows/ci.yml` — Replace all mutable tag/branch refs (`@v4`, `@main`, `@v3.1.1`) with SHA-pinned refs and version comments
- `renovate.json` — Add `helpers:pinGitHubActionDigests` preset explicitly

## Test Plan
- [ ] CI passes with SHA-pinned action references
- [ ] No `@main` or mutable tag references remain in workflow files
- [ ] Renovate creates update PRs for GitHub Actions when new versions are released
- [ ] Renovate creates update PRs for aqua packages (gitleaks, lefthook, aqua-registry)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
