### PR TITLE
Add power menu to Waybar with wlogout

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -10,6 +10,7 @@ in
     ./fcitx5.nix
     ./wofi.nix
     ./waybar.nix
+    ./wlogout.nix
     ./editors.nix
     ./mako.nix
     ./shell.nix

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -111,6 +111,38 @@ in
     };
   };
 
+  # Screen lock
+  programs.hyprlock = {
+    enable = true;
+    settings = {
+      general = {
+        hide_cursor = true;
+      };
+      background = [
+        {
+          monitor = "";
+          path = "screenshot";
+          blur_passes = 3;
+          blur_size = 8;
+        }
+      ];
+      input-field = [
+        {
+          monitor = "";
+          size = "200, 50";
+          outline_thickness = 3;
+          dots_size = 0.33;
+          dots_spacing = 0.15;
+          outer_color = "rgb(137, 180, 250)";
+          inner_color = "rgb(30, 30, 46)";
+          font_color = "rgb(205, 214, 244)";
+          fade_on_empty = true;
+          placeholder_text = "<i>Password...</i>";
+        }
+      ];
+    };
+  };
+
   # Terminal emulator
   programs.ghostty = {
     enable = true;

--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -42,8 +42,19 @@
       #network,
       #pulseaudio,
       #bluetooth,
-      #tray {
+      #tray,
+      #custom-power {
         padding: 0 10px;
+      }
+
+      #custom-power {
+        color: #f38ba8;
+      }
+
+      #custom-power:hover {
+        color: #cdd6f4;
+        background: rgba(243, 139, 168, 0.25);
+        border-radius: 4px;
       }
     '';
 
@@ -60,6 +71,7 @@
           "pulseaudio"
           "bluetooth"
           "tray"
+          "custom/power"
         ];
 
         "hyprland/workspaces" = {
@@ -120,6 +132,12 @@
         tray = {
           icon-size = 18;
           spacing = 10;
+        };
+
+        "custom/power" = {
+          format = "󰐥";
+          tooltip = false;
+          on-click = "wlogout";
         };
       };
     };

--- a/home/wlogout.nix
+++ b/home/wlogout.nix
@@ -1,0 +1,103 @@
+{ ... }:
+{
+  programs.wlogout = {
+    enable = true;
+
+    layout = [
+      {
+        label = "lock";
+        action = "hyprlock";
+        text = "󰌾  Lock";
+        keybind = "l";
+      }
+      {
+        label = "logout";
+        action = "hyprctl dispatch exit";
+        text = "󰍃  Logout";
+        keybind = "e";
+      }
+      {
+        label = "suspend";
+        action = "systemctl suspend";
+        text = "󰤄  Suspend";
+        keybind = "u";
+      }
+      {
+        label = "reboot";
+        action = "systemctl reboot";
+        text = "󰜉  Reboot";
+        keybind = "r";
+      }
+      {
+        label = "shutdown";
+        action = "systemctl poweroff";
+        text = "󰐥  Shutdown";
+        keybind = "s";
+      }
+    ];
+
+    style = ''
+      * {
+        background-image: none;
+        font-family: "HackGen35 Console NF", monospace;
+        font-size: 16px;
+      }
+
+      window {
+        background-color: rgba(30, 30, 46, 0.85);
+      }
+
+      button {
+        color: #cdd6f4;
+        background-color: #313244;
+        border: none;
+        border-radius: 12px;
+        margin: 10px;
+      }
+
+      button:hover {
+        background-color: #45475a;
+      }
+
+      button:focus {
+        background-color: #45475a;
+        outline: 2px solid #89b4fa;
+      }
+
+      #lock {
+        background-color: rgba(137, 180, 250, 0.15);
+      }
+      #lock:hover {
+        background-color: rgba(137, 180, 250, 0.3);
+      }
+
+      #logout {
+        background-color: rgba(166, 227, 161, 0.15);
+      }
+      #logout:hover {
+        background-color: rgba(166, 227, 161, 0.3);
+      }
+
+      #suspend {
+        background-color: rgba(249, 226, 175, 0.15);
+      }
+      #suspend:hover {
+        background-color: rgba(249, 226, 175, 0.3);
+      }
+
+      #reboot {
+        background-color: rgba(250, 179, 135, 0.15);
+      }
+      #reboot:hover {
+        background-color: rgba(250, 179, 135, 0.3);
+      }
+
+      #shutdown {
+        background-color: rgba(243, 139, 168, 0.15);
+      }
+      #shutdown:hover {
+        background-color: rgba(243, 139, 168, 0.3);
+      }
+    '';
+  };
+}


### PR DESCRIPTION
## Summary
- Add a power button (󰐥) to the right side of Waybar that opens wlogout on click
- Configure wlogout with 5 operations: lock, logout, suspend, reboot, shutdown
- Add hyprlock as the screen lock tool with screenshot blur background

Closes #90

## Changes
- `home/wlogout.nix` (new): wlogout layout and Catppuccin Mocha CSS styling
- `home/hyprland.nix`: add `programs.hyprlock` with blur screenshot background and themed input field
- `home/waybar.nix`: add `custom/power` module to modules-right with red power icon and hover effect
- `home/default.nix`: import `./wlogout.nix`

## Test Plan
- [ ] Power button is visible on the right side of Waybar (after tray)
- [ ] Clicking the power button opens wlogout with full-screen overlay
- [ ] wlogout shows 5 buttons: Lock, Logout, Suspend, Reboot, Shutdown
- [ ] Lock button launches hyprlock with blur screenshot background
- [ ] Logout exits Hyprland session
- [ ] Suspend, Reboot, Shutdown perform expected system operations
- [ ] wlogout styling matches Catppuccin Mocha theme
- [ ] Keyboard shortcuts work in wlogout (l/e/u/r/s)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
