### PR TITLE
Adjust 4K monitor scale to unify text size across monitors

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -15,7 +15,7 @@ in
       monitor = [
         "DP-6, 2560x1440@144, 0x0, 1" # JAPANNEXT (left)
         "DP-9, 2560x1440@144, 2560x0, 1" # DELL G3223D (center)
-        "DP-8, 3840x2160@60, 5120x0, 1.5" # LG HDR 4K (right)
+        "DP-8, 3840x2160@60, 5120x0, 1.75" # LG HDR 4K (right)
       ];
 
       # Workspace-to-monitor assignment (round-robin: left → center → right)


### PR DESCRIPTION
## Summary
- Change the LG 4K (27") monitor scale from 1.5 to 1.75 to match the effective PPI of the 31.5" 2K monitors
- This eliminates the ~16% text size difference between monitors

Closes #99

## Changes
- `home/hyprland.nix`: Update `DP-8` monitor scale from `1.5` to `1.75`

## Test Plan
- [ ] After `nixos-rebuild switch`, compare text size in a terminal/editor across all three monitors side-by-side
- [ ] Verify monitor layout has no overlapping or gaps (cursor moves smoothly between monitors)
- [ ] Verify all workspaces are correctly assigned to their respective monitors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
