### PR TITLE
Fix Dvorak xremap keycodes and add Mac-style shortcuts

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -70,7 +70,7 @@ in
 
       bind = [
         "$mod, D, exec, rofi -show drun -show-icons"
-        "$mod, V, exec, cliphist list | rofi -dmenu | cliphist decode | wl-copy"
+        "$mod, P, exec, cliphist list | rofi -dmenu | cliphist decode | wl-copy"
         "$mod, Return, exec, $terminal"
         "$mod, W, killactive"
         "$mod, M, exit"

--- a/modules/xremap.nix
+++ b/modules/xremap.nix
@@ -6,25 +6,30 @@
     serviceMode = "user";
     userName = "aoshima";
     # xremap operates at the evdev level (keycodes), but Hyprland applies the
-    # Dvorak layout AFTER xremap's output. Output keycodes must be reverse-mapped
-    # through Dvorak so the application receives the correct keysyms:
-    #   KEY_I   → Dvorak → keysym 'c'
-    #   KEY_DOT → Dvorak → keysym 'v'
+    # Dvorak layout AFTER xremap's output. Both input and output keycodes must
+    # use Dvorak physical positions (QWERTY keycode names):
+    #   'c' = KEY_I, 'v' = KEY_DOT, 'z' = KEY_SLASH, 'a' = KEY_A, 'e' = KEY_D
     config.keymap = [
       {
-        name = "Terminal: Super+C/V to Ctrl+Shift+C/V";
+        name = "Terminal: Mac-style shortcuts";
         application.only = [ "com.mitchellh.ghostty" ];
         remap = {
-          "Super-c" = "C-Shift-i";
-          "Super-v" = "C-Shift-dot";
+          "Super-i" = "C-Shift-i"; # Super+C → Ctrl+Shift+C (copy)
+          "Super-dot" = "C-Shift-dot"; # Super+V → Ctrl+Shift+V (paste)
+          "Super-slash" = "C-slash"; # Super+Z → Ctrl+Z (undo)
+          "Super-a" = "C-a"; # Super+A → Ctrl+A (select all)
         };
       }
       {
-        name = "GUI: Super+C/V to Ctrl+C/V";
+        name = "GUI: Mac-style shortcuts and Emacs navigation";
         application.not = [ "com.mitchellh.ghostty" ];
         remap = {
-          "Super-c" = "C-i";
-          "Super-v" = "C-dot";
+          "Super-i" = "C-i"; # Super+C → Ctrl+C (copy)
+          "Super-dot" = "C-dot"; # Super+V → Ctrl+V (paste)
+          "Super-slash" = "C-slash"; # Super+Z → Ctrl+Z (undo)
+          "Super-a" = "C-a"; # Super+A → Ctrl+A (select all)
+          "C-a" = "Home"; # Ctrl+A → beginning of line
+          "C-d" = "End"; # Ctrl+E → end of line
         };
       }
     ];


### PR DESCRIPTION
## Summary
- Fix xremap input keycodes to use Dvorak physical key positions (e.g., `Super-c` → `Super-i` for KEY_I)
- Add Super+Z (undo) and Super+A (select all) shortcuts for all applications
- Add Emacs-style Ctrl+A (Home) and Ctrl+E (End) for GUI applications (not terminals)
- Move cliphist clipboard history binding from Super+V to Super+P to avoid paste conflict

Closes #100

## Changes
- `modules/xremap.nix` — Fix input keycodes, add Super+Z/A and Ctrl+A/E mappings
- `home/hyprland.nix` — Change cliphist binding from `$mod, V` to `$mod, P`

## Test Plan
- [ ] Super+C copies text in Firefox
- [ ] Super+V pastes text in Firefox
- [ ] Super+Z undoes in Firefox
- [ ] Super+A selects all in Firefox
- [ ] Super+C/V works in Ghostty (Ctrl+Shift+C/V)
- [ ] Super+Z/A works in Ghostty
- [ ] Ctrl+A moves cursor to beginning of line in Firefox/Obsidian
- [ ] Ctrl+E moves cursor to end of line in Firefox/Obsidian
- [ ] Super+P opens cliphist clipboard history
- [ ] Super+V no longer opens cliphist
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
