### PR TITLE
Disable workspace wrapping when cycling with Ctrl+Arrow / mouse buttons

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -5,6 +5,26 @@ let
     hyprctl clients -j | jq -r ".[] | select(.workspace.id == $ws) | .address" \
       | xargs -I{} hyprctl dispatch closewindow address:{}
   '';
+
+  workspaceNoWrap = pkgs.writeShellScript "hypr-workspace-no-wrap" ''
+    direction=$1
+    ws_json=$(hyprctl activeworkspace -j)
+    current=$(echo "$ws_json" | jq '.id')
+    monitor=$(echo "$ws_json" | jq -r '.monitor')
+
+    case "$monitor" in
+      DP-6) first=1; last=7 ;;
+      DP-9) first=2; last=8 ;;
+      DP-8) first=3; last=9 ;;
+      *) exit 0 ;;
+    esac
+
+    if [ "$direction" = "next" ]; then
+      [ "$current" -ne "$last" ] && hyprctl dispatch workspace m+1
+    else
+      [ "$current" -ne "$first" ] && hyprctl dispatch workspace m-1
+    fi
+  '';
 in
 {
   wayland.windowManager.hyprland = {
@@ -97,11 +117,11 @@ in
         "$mod, Tab, cyclenext"
         "$mod SHIFT, Tab, cyclenext, prev"
 
-        # Cycle workspaces on active monitor
-        "CTRL, Right, workspace, m+1"
-        "CTRL, Left, workspace, m-1"
-        ", mouse:276, workspace, m+1" # MX Ergo forward button
-        ", mouse:275, workspace, m-1" # MX Ergo back button
+        # Cycle workspaces on active monitor (no wrap at boundaries)
+        "CTRL, Right, exec, ${workspaceNoWrap} next"
+        "CTRL, Left, exec, ${workspaceNoWrap} prev"
+        ", mouse:276, exec, ${workspaceNoWrap} next" # MX Ergo forward button
+        ", mouse:275, exec, ${workspaceNoWrap} prev" # MX Ergo back button
 
         # Delete workspace (close all windows)
         "$mod SHIFT, W, exec, ${closeAllWindows}"


### PR DESCRIPTION
## Summary
- Replace `workspace, m+1`/`m-1` dispatchers with a boundary-checking shell script
- Navigation stops at the first/last workspace on each monitor instead of wrapping around
- Affects all 4 workspace cycling keybindings (Ctrl+Left/Right, MX Ergo forward/back)

Closes #103

## Changes
- `home/hyprland.nix`: Add `workspaceNoWrap` shell script that queries `hyprctl activeworkspace` to check boundaries before dispatching, and update 4 keybindings to use it

## Test Plan
- [ ] Ctrl+Right on last workspace of a monitor (e.g., WS 7 on DP-6) stays on that workspace
- [ ] Ctrl+Left on first workspace of a monitor (e.g., WS 1 on DP-6) stays on that workspace
- [ ] Mouse forward/back buttons exhibit the same non-wrapping behavior
- [ ] Workspace navigation between non-boundary workspaces works as before
- [ ] `nix fmt` passes
- [ ] `nix flake check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
