### PR TITLE
Add hyprexpo plugin for workspace overview

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -30,6 +30,7 @@ in
   wayland.windowManager.hyprland = {
     enable = true;
     systemd.enable = false;
+    plugins = [ pkgs.hyprlandPlugins.hyprexpo ];
     settings = {
       # Monitor layout (left to right): JAPANNEXT 2K → DELL 2K → LG 4K
       monitor = [
@@ -73,6 +74,12 @@ in
         "blur on, match:namespace waybar"
       ];
 
+      plugin.hyprexpo = {
+        columns = 3;
+        gap_size = 5;
+        workspace_method = "first m+0";
+      };
+
       "$mod" = "SUPER";
       "$terminal" = "ghostty";
 
@@ -112,6 +119,9 @@ in
         "$mod SHIFT, 1, movewindow, mon:DP-6" # left
         "$mod SHIFT, 2, movewindow, mon:DP-9" # center
         "$mod SHIFT, 3, movewindow, mon:DP-8" # right
+
+        # Workspace overview (hyprexpo)
+        "$mod, grave, hyprexpo:expo, toggle"
 
         # Cycle windows on active workspace
         "$mod, Tab, cyclenext"


### PR DESCRIPTION
## Summary
- Add hyprexpo (official Hyprland plugin) for per-monitor workspace overview
- Configure 3-column grid to match the 3-workspace-per-monitor layout
- Bind `$mod + grave` to toggle the overview

Closes #105

## Changes
- `home/hyprland.nix`: Add `hyprlandPlugins.hyprexpo` to plugins, add `plugin.hyprexpo` configuration (columns, gap_size, workspace_method), add keybind

## Test Plan
- [x] `nix fmt` — format check passes
- [x] `nix flake check` — configuration evaluates successfully
- [ ] `nixos-rebuild switch` — verify hyprexpo loads and `$mod+grave` toggles workspace overview
- [ ] Verify each monitor shows only its own 3 workspaces in the overview
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
