### PR TITLE
Fix xremap not starting by launching Hyprland via uwsm

### DIFF
--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -9,7 +9,7 @@
     enable = true;
     settings = {
       default_session = {
-        command = "${pkgs.tuigreet}/bin/tuigreet --time --cmd start-hyprland";
+        command = "${pkgs.tuigreet}/bin/tuigreet --time --cmd 'uwsm start hyprland-uwsm.desktop'";
         user = "greeter";
       };
     };


### PR DESCRIPTION
## Summary
- Fix greetd to launch Hyprland through uwsm (`uwsm start hyprland-uwsm.desktop`) instead of directly via `start-hyprland`
- This activates `graphical-session.target`, which xremap.service depends on via `WantedBy`
- Root cause: `start-hyprland` is a native Hyprland binary that bypasses uwsm session management entirely

## Root Cause Analysis
1. greetd ran `start-hyprland` directly — a native Hyprland binary with no uwsm integration
2. uwsm's `wayland-session@.target` was never instantiated
3. `graphical-session.target` remained inactive
4. xremap.service (`WantedBy=graphical-session.target`) never started
5. All keyboard remappings (Super+C/V/Z/A, Ctrl+A/E) were non-functional

## Test plan
- [ ] After `nixos-rebuild switch` and reboot, verify `systemctl --user status graphical-session.target` is active
- [ ] Verify `systemctl --user status xremap.service` is active (running)
- [ ] Verify Super+C copies text in Firefox
- [ ] Verify Super+V pastes text in Firefox
- [ ] Verify Ctrl+A moves cursor to beginning of line in Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
