### PR TITLE
Fix Japanese IME by removing duplicate fcitx5 startup

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -60,7 +60,6 @@ in
       };
 
       exec-once = [
-        "fcitx5 -d"
         "waybar"
         "blueman-applet"
       ];


### PR DESCRIPTION
## Summary
- Removed manual `fcitx5 -d` from Hyprland's `exec-once`
- The bare fcitx5 (without mozc) was grabbing the DBus name before Home Manager's `fcitx5-daemon.service` could start `fcitx5-with-addons`, causing the systemd service to fail and leaving the system without Japanese input
- Home Manager's systemd service (`fcitx5-daemon.service`) already handles fcitx5 startup via `graphical-session.target`

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#desktop-01`
- [ ] Log out and log back in (or restart fcitx5)
- [ ] Verify Japanese IME (mozc) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
