### PR TITLE
Declare fcitx5 input method profile with mozc

### DIFF
--- a/home/fcitx5.nix
+++ b/home/fcitx5.nix
@@ -6,6 +6,22 @@
     fcitx5 = {
       addons = [ pkgs.fcitx5-mozc ];
       waylandFrontend = true;
+      settings.inputMethod = {
+        "Groups/0" = {
+          Name = "デフォルト";
+          "Default Layout" = "us";
+          DefaultIM = "keyboard-us";
+        };
+        "Groups/0/Items/0" = {
+          Name = "keyboard-us";
+          Layout = "";
+        };
+        "Groups/0/Items/1" = {
+          Name = "mozc";
+          Layout = "";
+        };
+        GroupOrder."0" = "デフォルト";
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- Add `settings.inputMethod` to declaratively manage the fcitx5 profile via Home Manager
- Ensures mozc is always registered as an available input method alongside keyboard-us
- Previously only the mozc addon was installed (`addons`), but the profile (which input methods are active) was not managed, causing mozc to be missing after fresh fcitx5 startup

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#desktop-01`
- [ ] Log out and log back in
- [ ] Verify `Ctrl+Space` toggles Japanese input (mozc)
- [ ] Verify `~/.config/fcitx5/profile` contains mozc entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
