### PR TITLE
Add sops and age CLI packages to system

### DIFF
--- a/modules/sops.nix
+++ b/modules/sops.nix
@@ -1,5 +1,10 @@
-{ ... }:
+{ pkgs, ... }:
 {
+  environment.systemPackages = with pkgs; [
+    sops
+    age
+  ];
+
   sops.defaultSopsFile = ../secrets/secrets.yaml;
   sops.age.sshKeyPaths = [ ];
   sops.age.keyFile = "/var/lib/sops-nix/key.txt";


### PR DESCRIPTION
## Summary
- Add `sops` and `age` CLI packages to `environment.systemPackages` in `modules/sops.nix`
- Enables interactive secret editing via `sops secrets/secrets.yaml` on the NixOS machine

## Test plan
- [ ] Run `sudo nixos-rebuild switch --flake .#desktop-01`
- [ ] Verify `sops` and `age` commands are available in PATH
- [ ] Verify `sops secrets/secrets.yaml` opens and decrypts secrets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
