### PR TITLE
Enable nix-command and flakes experimental features globally

### DIFF
--- a/hosts/desktop-01/default.nix
+++ b/hosts/desktop-01/default.nix
@@ -24,6 +24,12 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Enable flakes and nix command globally
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
   # Networking
   networking.hostName = "desktop-01";
   networking.networkmanager.enable = true;


### PR DESCRIPTION
## Summary
- Add `nix.settings.experimental-features` with `nix-command` and `flakes` to `hosts/desktop-01/default.nix`
- Eliminates the need for `--extra-experimental-features` flag on every `nix` subcommand invocation

Closes #109

## Changes
- `hosts/desktop-01/default.nix`: Add `nix.settings.experimental-features = [ "nix-command" "flakes" ];`

## Test Plan
- [ ] CI passes (format check, gitleaks, nix eval)
- [ ] After `nixos-rebuild switch`, `nix fmt` works without `--extra-experimental-features` flag
- [ ] After `nixos-rebuild switch`, `nix flake check` works without the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
