### PR TITLE
Change app launcher keybinding from Super+D to Super+Space

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -97,7 +97,7 @@ in
       ];
 
       bind = [
-        "$mod, D, exec, rofi -show drun -show-icons"
+        "$mod, Space, exec, rofi -show drun -show-icons"
         "$mod, P, exec, cliphist list | rofi -dmenu | cliphist decode | wl-copy"
         "$mod, Return, exec, $terminal"
         "$mod, W, killactive"


### PR DESCRIPTION
## Summary
- Change rofi app launcher keybinding from `Super+D` to `Super+Space` for macOS Spotlight-like muscle memory

Closes #113

## Changes
- `home/hyprland.nix`: Replace `$mod, D` with `$mod, Space` in the `bind` list (line 100)

## Test Plan
- [ ] `nix fmt -- --check home/hyprland.nix` passes
- [ ] `nix flake check` passes (CI)
- [ ] After `nixos-rebuild switch`, pressing `Super+Space` opens rofi app launcher
- [ ] Pressing `Super+D` does not trigger any action
- [ ] All other keybindings remain functional
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
