### PR TITLE
Add volume slider popup to Waybar volume widget

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -74,6 +74,13 @@ in
         "blur on, match:namespace waybar"
       ];
 
+      windowrulev2 = [
+        "float, class:volume-popup"
+        "noborder, class:volume-popup"
+        "noshadow, class:volume-popup"
+        "move onscreen cursor -150 30, class:volume-popup"
+      ];
+
       # TODO: Re-enable when hyprexpo is updated to match Hyprland 0.54.x in nixpkgs
       # plugin.hyprexpo = {
       #   columns = 3;

--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -1,4 +1,128 @@
 { pkgs, ... }:
+let
+  python = pkgs.python3.withPackages (ps: [ ps.pygobject3 ]);
+
+  volumePopupPy = pkgs.writeText "volume-popup.py" ''
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+    from gi.repository import Gtk, Gdk, GLib
+    import subprocess
+    import os
+    import signal
+    import sys
+
+    PID_FILE = '/tmp/volume-popup.pid'
+
+
+    def kill_existing():
+        try:
+            with open(PID_FILE) as f:
+                pid = int(f.read().strip())
+            os.kill(pid, signal.SIGTERM)
+            return True
+        except (FileNotFoundError, ValueError, ProcessLookupError):
+            pass
+        return False
+
+
+    def get_volume():
+        result = subprocess.run(
+            ['wpctl', 'get-volume', '@DEFAULT_AUDIO_SINK@'],
+            capture_output=True, text=True
+        )
+        parts = result.stdout.strip().split()
+        return float(parts[1]) * 100
+
+
+    def set_volume(value):
+        subprocess.run([
+            'wpctl', 'set-volume', '-l', '1.0',
+            '@DEFAULT_AUDIO_SINK@', str(round(value / 100, 2))
+        ])
+
+
+    if kill_existing():
+        try:
+            os.remove(PID_FILE)
+        except FileNotFoundError:
+            pass
+        sys.exit(0)
+
+    with open(PID_FILE, 'w') as f:
+        f.write(str(os.getpid()))
+
+    GLib.set_prgname('volume-popup')
+
+    win = Gtk.Window(title='Volume')
+    win.set_default_size(300, -1)
+    win.set_decorated(False)
+    win.set_resizable(False)
+
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+    box.set_margin_start(10)
+    box.set_margin_end(10)
+    box.set_margin_top(8)
+    box.set_margin_bottom(8)
+
+    adj = Gtk.Adjustment(
+        value=get_volume(), lower=0, upper=100,
+        step_increment=1, page_increment=5
+    )
+    scale = Gtk.Scale(
+        orientation=Gtk.Orientation.HORIZONTAL,
+        adjustment=adj
+    )
+    scale.set_digits(0)
+    scale.set_value_pos(Gtk.PositionType.RIGHT)
+    scale.connect('value-changed', lambda s: set_volume(s.get_value()))
+
+    box.add(scale)
+    win.add(box)
+
+
+    def quit_app(*args):
+        try:
+            os.remove(PID_FILE)
+        except OSError:
+            pass
+        Gtk.main_quit()
+        return False
+
+
+    def on_key_press(widget, event):
+        if event.keyval == Gdk.KEY_Escape:
+            quit_app()
+            return True
+        return False
+
+
+    win.connect('destroy', lambda w: quit_app())
+    win.connect('focus-out-event', lambda w, e: quit_app())
+    win.connect('key-press-event', on_key_press)
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, quit_app)
+
+    win.show_all()
+    Gtk.main()
+  '';
+
+  giTypelibPath = pkgs.lib.makeSearchPath "lib/girepository-1.0" (
+    with pkgs;
+    [
+      gobject-introspection
+      gtk3
+      glib
+      pango
+      gdk-pixbuf
+      harfbuzz
+    ]
+  );
+
+  volumePopup = pkgs.writeShellScript "volume-popup" ''
+    export GI_TYPELIB_PATH="${giTypelibPath}"
+    exec ${python}/bin/python3 ${volumePopupPy}
+  '';
+in
 {
   home.packages = [ pkgs.pavucontrol ];
 
@@ -117,8 +241,11 @@
               "󰕾"
             ];
           };
-          on-click = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+          on-click = "${volumePopup}";
+          on-click-middle = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
           on-click-right = "pavucontrol";
+          on-scroll-up = "wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 2%+";
+          on-scroll-down = "wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%-";
         };
 
         bluetooth = {


### PR DESCRIPTION
## Summary
- Add a Python GTK3 popup slider that appears on left-clicking the Waybar volume icon for precise volume adjustment
- Remap click actions: left-click → popup, middle-click → mute toggle, right-click → pavucontrol (unchanged)
- Add scroll-based volume control (2% increments) on the Waybar volume widget
- Add Hyprland window rules to position the popup as a floating borderless window below Waybar

Closes #114

## Changes
- `home/waybar.nix` — Add volume popup Python GTK3 script (with PID-based toggle, wpctl integration, focus-out/Escape dismissal), update pulseaudio widget click/scroll handlers, add GI typelib path setup
- `home/hyprland.nix` — Add `windowrulev2` rules for `volume-popup` class (float, noborder, noshadow, cursor-relative positioning)

## Test Plan
- [ ] Click Waybar volume icon → slider popup appears below the widget
- [ ] Slider reflects current volume level
- [ ] Drag slider → volume changes in real-time
- [ ] Click volume icon again → popup dismisses (toggle)
- [ ] Press Escape → popup dismisses
- [ ] Click outside popup → popup dismisses (focus-out)
- [ ] Middle-click volume icon → mute toggles
- [ ] Right-click volume icon → pavucontrol opens
- [ ] Scroll up/down on volume icon → volume adjusts by 2%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
