### PR TITLE
Remove duplicate Bluetooth icon from Waybar

### DIFF
--- a/modules/bluetooth.nix
+++ b/modules/bluetooth.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 {
   hardware.bluetooth = {
     enable = true;
@@ -12,4 +12,8 @@
   };
 
   services.blueman.enable = true;
+
+  # Prevent blueman-applet from auto-starting; the Waybar bluetooth module
+  # provides the tray icon with rofi-bluetooth / blueman-manager on click.
+  systemd.user.services.blueman-applet.wantedBy = lib.mkForce [ ];
 }


### PR DESCRIPTION
## Summary
- Prevent blueman-applet from auto-starting by overriding its systemd user service `wantedBy` to an empty list
- Keep `services.blueman.enable = true` so the D-Bus mechanism service remains available for blueman-manager

Closes #119

## Changes
- `modules/bluetooth.nix`: Add `lib` to function args; override `systemd.user.services.blueman-applet.wantedBy` with `lib.mkForce []`

## Test Plan
- [ ] Only one Bluetooth icon is visible in Waybar after login
- [ ] Left-clicking the Bluetooth icon launches rofi-bluetooth
- [ ] Right-clicking the Bluetooth icon opens blueman-manager
- [ ] Bluetooth pairing and connection functionality works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
