### PR TITLE
Fix fcitx5 tray icon showing white square in English mode

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -125,6 +125,14 @@ in
     PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
   };
 
+  gtk = {
+    enable = true;
+    iconTheme = {
+      name = "Adwaita";
+      package = pkgs.adwaita-icon-theme;
+    };
+  };
+
   programs.gh = {
     enable = true;
     gitCredentialHelper.enable = true;


### PR DESCRIPTION
## Summary
- Set Adwaita as the GTK icon theme via Home Manager's `gtk.iconTheme`
- This provides the `input-keyboard` icon that fcitx5's keyboard-us input method relies on for its tray icon

Closes #120

## Changes
- `home/default.nix`: Add `gtk.enable = true` and `gtk.iconTheme` configuration with `adwaita-icon-theme`

## Test Plan
- [ ] `nix fmt -- --check` passes
- [ ] `nix eval .#nixosConfigurations.desktop-01.config.system.build.toplevel` succeeds
- [ ] After `nixos-rebuild switch`, switching to keyboard-us shows a recognizable icon (not white square)
- [ ] Switching to Mozc continues to show its icon correctly
- [ ] The two input modes are visually distinguishable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
