### PR TITLE
Show WiFi signal strength instead of SSID in Waybar

### DIFF
--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -121,10 +121,11 @@
         };
 
         network = {
-          format-wifi = "  {essid}";
+          format-wifi = "  {signalStrength}%";
           format-ethernet = "󰈀  {ipaddr}";
           format-disconnected = "󰖪  Disconnected";
           tooltip-format = "{ifname}: {ipaddr}/{cidr}";
+          tooltip-format-wifi = "{essid}\n{ifname}: {ipaddr}/{cidr}\nSignal: {signalStrength}%";
         };
 
         "group/audio" = {


### PR DESCRIPTION
## Summary
- Replace WiFi SSID display with signal strength percentage in Waybar network module
- Add WiFi-specific tooltip showing SSID, IP address, and signal strength
- Ethernet and disconnected states remain unchanged

Closes #122

## Changes
- `home/waybar.nix`: Change `format-wifi` from `{essid}` to `{signalStrength}%`, add `tooltip-format-wifi` with SSID and connection details

## Test Plan
- [ ] Waybar WiFi display shows signal strength percentage (e.g., "  75%")
- [ ] Hovering over WiFi shows tooltip with SSID, IP, and signal strength
- [ ] Ethernet display unchanged ("󰈀  {ipaddr}")
- [ ] Disconnected display unchanged ("󰖪  Disconnected")
- [ ] Apply with `sudo nixos-rebuild switch --flake .#desktop-01` on NixOS machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
