### PR TITLE
Fix forward workspace cycling wrap-around at monitor boundaries

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -20,9 +20,9 @@ let
     esac
 
     if [ "$direction" = "next" ]; then
-      [ "$current" -ne "$last" ] && hyprctl dispatch workspace m+1
+      [ "$current" -ne "$last" ] && hyprctl dispatch workspace "$((current + 3))"
     else
-      [ "$current" -ne "$first" ] && hyprctl dispatch workspace m-1
+      [ "$current" -ne "$first" ] && hyprctl dispatch workspace "$((current - 3))"
     fi
   '';
 in


### PR DESCRIPTION
## Summary
- Replace relative workspace navigation (`workspace m+1`/`m-1`) with absolute workspace IDs (`workspace $((current ± 3))`) in the `workspaceNoWrap` script
- Hyprland's `m+1` command wraps around at the last workspace on a monitor, bypassing the boundary check; using absolute IDs avoids this behavior entirely

Closes #118

## Changes
- `home/hyprland.nix`: Changed dispatch commands in `workspaceNoWrap` from `workspace m+1`/`m-1` to `workspace "$((current + 3))"`/`workspace "$((current - 3))"`

## Test Plan
- [ ] On DP-6 workspace 7: Ctrl+Right does not change workspace
- [ ] On DP-9 workspace 8: Ctrl+Right does not change workspace
- [ ] On DP-8 workspace 9: Ctrl+Right does not change workspace
- [ ] Mouse forward button at last workspace does not change workspace
- [ ] Forward cycling between non-boundary workspaces works (e.g., WS1→WS4→WS7)
- [ ] Backward cycling still stops at first workspace (no regression)
- [ ] Backward cycling between non-boundary workspaces works (e.g., WS7→WS4→WS1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
