### PR TITLE
Remove Chrome tray icon from Waybar

### DIFF
--- a/home/browsers.nix
+++ b/home/browsers.nix
@@ -14,6 +14,7 @@
     (pkgs.google-chrome.override {
       commandLineArgs = [
         "--enable-features=VaapiVideoDecodeLinuxGL"
+        "--disable-background-mode"
       ];
     })
     pkgs.vivaldi


### PR DESCRIPTION
## Summary
- Add `--disable-background-mode` flag to Chrome's command-line arguments in `home/browsers.nix`
- This prevents Chrome from running in the background when all windows are closed, eliminating the tray icon from Waybar's system tray

Closes #121

## Changes
- `home/browsers.nix`: Added `"--disable-background-mode"` to `commandLineArgs` list

## Test Plan
- [ ] Run `nixos-rebuild switch` to apply the configuration
- [ ] Open Chrome, then close all Chrome windows
- [ ] Verify Chrome's icon no longer appears in Waybar's system tray
- [ ] Verify Chrome browsing and extensions work normally
- [ ] Verify other tray icons (fcitx5, etc.) still display correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
