### PR TITLE
Enable TUI Emacs clipboard integration with Wayland

### DIFF
--- a/home/editors.nix
+++ b/home/editors.nix
@@ -10,5 +10,12 @@
     package = pkgs.vscode;
   };
 
-  programs.emacs.enable = true;
+  programs.emacs = {
+    enable = true;
+    extraPackages = epkgs: [ epkgs.xclip ];
+  };
+
+  home.file.".emacs.d/init.el".text = ''
+    (xclip-mode 1)
+  '';
 }


### PR DESCRIPTION
## Summary
- Add `xclip` Emacs package and enable `xclip-mode` for Wayland clipboard integration in TUI Emacs (`emacs -nw`)
- `xclip-mode` detects Wayland and uses `wl-copy`/`wl-paste` (already installed via tmux.nix)
- GUI Emacs clipboard behavior is unaffected (xclip-mode only activates for terminal frames)

Closes #130

## Changes
- `home/editors.nix`: Add `extraPackages` with `epkgs.xclip`, create `~/.emacs.d/init.el` enabling `xclip-mode`

## Test Plan
- [ ] Copy text in browser → `C-y` in TUI Emacs yanks the text
- [ ] `C-w` / `M-w` in TUI Emacs → text available via `wl-paste` and appears in cliphist history
- [ ] GUI Emacs (`emacs`) clipboard works as before
- [ ] `nix eval` / `nix flake check` pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
