### PR TITLE
Enhance Emacs TUI mode with essential packages

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -13,6 +13,7 @@ in
     ./waybar.nix
     ./wlogout.nix
     ./editors.nix
+    ./emacs.nix
     ./mako.nix
     ./shell.nix
     ./tmux.nix

--- a/home/editors.nix
+++ b/home/editors.nix
@@ -10,12 +10,4 @@
     package = pkgs.vscode;
   };
 
-  programs.emacs = {
-    enable = true;
-    extraPackages = epkgs: [ epkgs.xclip ];
-  };
-
-  home.file.".emacs.d/init.el".text = ''
-    (xclip-mode 1)
-  '';
 }

--- a/home/emacs.nix
+++ b/home/emacs.nix
@@ -1,0 +1,117 @@
+{ ... }:
+{
+  programs.emacs = {
+    enable = true;
+    extraPackages =
+      epkgs: with epkgs; [
+        # Theme
+        dracula-theme
+
+        # Project management
+        projectile
+
+        # Git
+        magit
+        diff-hl
+
+        # Key discoverability
+        which-key
+
+        # Minibuffer completion
+        vertico
+        orderless
+        marginalia
+        consult
+
+        # Code completion
+        corfu
+
+        # File tree
+        treemacs
+
+        # Mode line
+        doom-modeline
+        nerd-icons
+
+        # Clipboard (supports wl-clipboard for Wayland)
+        xclip
+      ];
+    extraConfig = ''
+      ;; use-package (built into Emacs 29+)
+      (require 'use-package)
+
+      ;; Theme
+      (use-package dracula-theme
+        :config
+        (load-theme 'dracula t))
+
+      ;; Which-key: show available keybindings after prefix
+      (use-package which-key
+        :config
+        (which-key-mode))
+
+      ;; Project management
+      (use-package projectile
+        :config
+        (projectile-mode +1)
+        :bind-keymap
+        ("C-c p" . projectile-command-map))
+
+      ;; Vertico: vertical minibuffer completion
+      (use-package vertico
+        :config
+        (vertico-mode))
+
+      ;; Orderless: flexible completion matching
+      (use-package orderless
+        :custom
+        (completion-styles '(orderless basic)))
+
+      ;; Marginalia: completion annotations
+      (use-package marginalia
+        :config
+        (marginalia-mode))
+
+      ;; Consult: enhanced search and navigation commands
+      (use-package consult
+        :bind
+        (("C-s" . consult-line)
+         ("C-x b" . consult-buffer)))
+
+      ;; Corfu: in-buffer code completion
+      (use-package corfu
+        :custom
+        (corfu-auto t)
+        :config
+        (global-corfu-mode))
+
+      ;; Magit: Git interface
+      (use-package magit
+        :bind ("C-x g" . magit-status))
+
+      ;; diff-hl: inline Git diffs in gutter
+      (use-package diff-hl
+        :config
+        (global-diff-hl-mode)
+        (add-hook 'magit-pre-refresh-hook 'diff-hl-magit-pre-refresh)
+        (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh))
+
+      ;; Treemacs: file tree sidebar
+      (use-package treemacs
+        :bind ("C-x t t" . treemacs))
+
+      ;; Doom modeline: modern status bar
+      (use-package doom-modeline
+        :config
+        (doom-modeline-mode 1))
+
+      ;; Nerd icons (used by doom-modeline)
+      (use-package nerd-icons)
+
+      ;; Clipboard: integrates with wl-copy/wl-paste on Wayland
+      (use-package xclip
+        :config
+        (xclip-mode 1))
+    '';
+  };
+}


### PR DESCRIPTION
## Summary
- Add curated Emacs packages for productive terminal editing (theme, Git, completion, project management, file navigation)
- Extract Emacs config from `editors.nix` into dedicated `home/emacs.nix` module
- Configure Wayland clipboard integration via `wl-clipboard`

Closes #131

## Changes
- **`home/emacs.nix`** (new): Complete Emacs TUI configuration with 14 packages — Dracula theme, Projectile, Magit + diff-hl, Which-key, Vertico + Orderless + Marginalia + Consult, Corfu, Treemacs, Doom-modeline + Nerd-icons, xclip
- **`home/editors.nix`**: Remove `programs.emacs.enable = true;` (moved to emacs.nix)
- **`home/default.nix`**: Add `./emacs.nix` to imports

## Test Plan
- [x] `nix fmt` passes on all changed `.nix` files
- [x] `nix eval .#nixosConfigurations.desktop-01.config.system.build.toplevel` succeeds
- [ ] `emacs -nw` launches with Dracula theme applied
- [ ] `C-c p` opens Projectile command map
- [ ] `C-x g` opens Magit status
- [ ] `C-x t t` toggles Treemacs sidebar
- [ ] `C-s` uses consult-line, `C-x b` uses consult-buffer
- [ ] Which-key shows hints after pressing prefix keys (e.g., `C-x`)
- [ ] In-buffer completion appears automatically (Corfu)
- [ ] Mode line shows Git branch info (Doom-modeline)
- [ ] System clipboard copy/paste works in TUI mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
