### PR TITLE
Add sox to enable Claude Code /voice command

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -61,6 +61,7 @@ in
     # AI CLI
     codex
     gemini-cli
+    sox # for Claude Code /voice command
 
     # Shell productivity (fzf, zoxide, direnv are in shell.nix via programs.*)
     # bat and lazygit are managed via programs.* for theme configuration


### PR DESCRIPTION
## Summary

- Add `sox` to `home.packages` in `home/default.nix`

Closes #136

## Changes

- `home/default.nix`: Added `sox` package under the `# AI CLI` section

## Test Plan

- [ ] Run `nixos-rebuild switch --flake .#desktop-01` on the NixOS machine
- [ ] Verify `which sox` returns a path
- [ ] Open Claude Code and run `/voice` — confirm audio recording starts without "Install SoX" error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
