### PR TITLE
Rename swww to awww following nixpkgs upstream rename

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -122,7 +122,7 @@ in
     duf
 
     # Wallpaper
-    swww
+    awww
     waypaper
 
     # Thunar thumbnail support

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -79,7 +79,7 @@ in
         "waybar"
         "wl-gammarelay-rs run"
         "wl-gammarelay-applet"
-        "swww-daemon"
+        "awww-daemon"
         "waypaper --restore"
       ];
 


### PR DESCRIPTION
## Summary
- Rename `swww` package to `awww` in `home/default.nix`
- Rename `swww-daemon` to `awww-daemon` in `home/hyprland.nix`
- Fixes the evaluation warning: `'swww' has been renamed to 'awww'`

## Test plan
- [x] `nix fmt` passes
- [ ] CI passes
- [ ] `nixos-rebuild switch` applies without warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/nixos-config/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
